### PR TITLE
feat(calendar): added to simpler way to add a new calendar. 

### DIFF
--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -71,6 +71,8 @@ module.exports =
     "ON"                                : "on"
     "OFF"                               : "off"
     "no description"                    : "No description"
+    "add calendar"                      : "Add calendar"
+    "new calendar"                      : "New calendar"
 
 # RRULE related
     "recurrence"                        : "Recurrence"

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -70,6 +70,8 @@ module.exports =
     "ON"                                : "activée"
     "OFF"                               : "désactivée"
     "no description"                    : "Sans description"
+    "add calendar"                      : "Ajouter un calendrier"
+    "new calendar"                      : "Nouveau calendrier"
 
 # RRULE related
     "recurrence"                        : "Récurrence"

--- a/client/app/views/menu.coffee
+++ b/client/app/views/menu.coffee
@@ -27,11 +27,13 @@ module.exports = class MenuView extends ViewCollection
                 place: ''
                 tags: [t("new calendar")]
         # saving the event, creating calendar
-        calendarEvent.save {}
-        #a timeout is needed for the created calendar to appear on bottom of the menu items
-        setTimeout ->
-            $('#menuitems li.tagmenuitem:last-of-type .calendar-rename').trigger("click")
-        ,100
+        calendarEvent.save null,
+            wait: true
+            success: =>
+                #a timeout is needed for the created calendar to appear on bottom of the menu items
+                setTimeout ->
+                    $('#menuitems li.tagmenuitem:last-of-type .calendar-rename').trigger("click")
+                , 100
 
     activate: (href) ->
         @$('.active').removeClass 'active'

--- a/client/app/views/menu.coffee
+++ b/client/app/views/menu.coffee
@@ -1,5 +1,8 @@
+colorhash = require 'lib/colorhash'
 ViewCollection = require '../lib/view_collection'
-
+ComboBox    = require 'views/widgets/combobox'
+Event       = require 'models/event'
+Tag = require 'models/tag'
 
 module.exports = class MenuView extends ViewCollection
 
@@ -12,6 +15,23 @@ module.exports = class MenuView extends ViewCollection
 
     events: ->
         'click .calendars': 'toggleDropdown'
+        'click .calendar-add': 'onAddCalendar'
+
+    onAddCalendar: ->
+        @tag = app.tags.getOrCreateByName "new calendar"
+        # Since an event is needed to create a calendar, let's make a false one
+        calendarEvent = new Event
+                start: moment("19010101", "YYYYMMDD")
+                end: moment("19010101", "YYYYMMDD")
+                description: ''
+                place: ''
+                tags: [t("new calendar")]
+        # saving the event, creating calendar
+        calendarEvent.save {}
+        #a timeout is needed for the created calendar to appear on bottom of the menu items
+        setTimeout ->
+            $('#menuitems li.tagmenuitem:last-of-type .calendar-rename').trigger("click")
+        ,100
 
     activate: (href) ->
         @$('.active').removeClass 'active'

--- a/client/app/views/styles/_menu.styl
+++ b/client/app/views/styles/_menu.styl
@@ -25,6 +25,9 @@ ul#menu
 
     a
         background: transparent
+        display: inline-block
+        &.calendar-add
+          width 150px
 
   li.divider
     background-color transparent
@@ -41,6 +44,39 @@ ul#menu
     i
         margin-right: 10px
         margin-left: 10px
+
+    &.calendars
+      .dropdown
+        display inline-block
+        .dropdown-toggle
+          padding 0 5px
+          .caret
+            display none
+            margin-top 0 !important // overrides bootstrap
+            vertical-align middle
+            border-top-color #000
+            border-bottom-color #000
+            opacity 0.2
+            transform scale(1.5, 1.5)
+
+        .dropdown-menu
+          border-radius 0
+          padding 0
+          li
+            margin 0
+            padding 0
+            a
+              padding 5px
+              &:hover
+                background #ffc47f
+
+
+      &:hover
+        .dropdown .dropdown-toggle .caret
+          display inline-block
+
+          &:hover
+            opacity 1
 
   &> li:hover
     background #FFC47F

--- a/client/app/views/templates/menu.jade
+++ b/client/app/views/templates/menu.jade
@@ -9,5 +9,11 @@ li.calendars
         i.fa.fa-calendar
         span
             = t('Calendar')
+        .dropdown
+            a#dLabel_.dropdown-toggle(data-toggle="dropdown")
+                span.caret
+            ul.dropdown-menu(aria-labelledBy='dLabel_')
+                li
+                    a.calendar-add= t('add calendar')
 
 ul#menuitems


### PR DESCRIPTION
Some css fixes may be nedeed

Added a submenu to "Calendar" menu item. same behaviour as menuitem.
On click, a new calendar is created and "rename" action is triggered so that the user can name it.

Due to codebase system (tag, no calendar without event), a fake event is created on 01/01/1901 for the new calendar to be saved.