### PR TITLE
feat(popover): when clicking on the color bullet, auto select the input ...

### DIFF
--- a/client/app/views/widgets/combobox.coffee
+++ b/client/app/views/widgets/combobox.coffee
@@ -45,6 +45,9 @@ module.exports = class ComboBox extends BaseView
         @menuOpen = true
         @$el.addClass 'expanded'
         @$el.focus().val(@value()).autocomplete 'search', ''
+        # when clicking on menu, auto selecting the input so that it
+        # can be updated when typing
+        @$el.select()
 
     setValue: (value) =>
         @$el.val value
@@ -74,7 +77,7 @@ module.exports = class ComboBox extends BaseView
     onEditionComplete: (name) =>
         @tag = app.tags.getOrCreateByName name
 
-        @buildBadge @tag.get 'color'        
+        @buildBadge @tag.get 'color'
 
     onChange: (ev, ui) =>
         value = ui?.item?.value or @value()


### PR DESCRIPTION
on a calendar popover,  when clicking on the color bullet, auto select the input text, so that when the user types the name is automatically changed.

at the moment, the cursor is placed after the current name. That means if the user inputs "foo", and the calendar is "calendar", the input contains "calendarfoo"

now, when the user inputs "foo", the name is "foo".

Addressing issue #218 