### PR TITLE
fix(icon missing): #223 changed icon name for 'duplicate link'

### DIFF
--- a/client/app/views/templates/popover_title.jade
+++ b/client/app/views/templates/popover_title.jade
@@ -19,4 +19,4 @@ span.controls
     button.close(title=t('close'), role="button") &times;
     i.remove.icon-trash(title=t('delete'), role="button")
     img.remove-spinner(src='img/spinner.svg')
-    i.duplicate.icon-files-o(title=t('duplicate'), role="button")
+    i.duplicate.icon-file(title=t('duplicate'), role="button")


### PR DESCRIPTION
Icon is not showing.

It seems a bit too far left.