### PR TITLE
CSS: added break-word to calendar name #299

### DIFF
--- a/client/app/views/styles/_menu.styl
+++ b/client/app/views/styles/_menu.styl
@@ -124,6 +124,7 @@
             .calendar-name
                 font-size 1em
                 color #555
+                word-break break-word
 
             input.calendar-name
                 width 100px

--- a/client/app/views/styles/_menu.styl
+++ b/client/app/views/styles/_menu.styl
@@ -122,9 +122,10 @@
                 border-radius 100%
 
             .calendar-name
+                width 100%
                 font-size 1em
                 color #555
-                word-break break-word
+                word-break break-all
 
             input.calendar-name
                 width 100px


### PR DESCRIPTION
Access options when the calendar name is too long.