### PR TITLE
Fixed: invitation ICS are marked as request to prevent bugs  when reimported in other clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "americano": "0.3.11",
     "archiver": "0.14.4",
     "async": "1.3.0",
-    "cozy-ical": "1.1.12",
+    "cozy-ical": "1.1.13",
     "cozy-realtime-adapter": "1.0.0",
     "cozydb": "0.0.17",
     "jade": "1.3.1",

--- a/server/mails/mail_handler.coffee
+++ b/server/mails/mail_handler.coffee
@@ -79,8 +79,11 @@ module.exports.sendInvitations = (event, dateChanged, callback) ->
             calendarOptions =
                 organization:'Cozy Cloud'
                 title: 'Cozy Calendar'
+                method: 'REQUEST'
+
             calendar = new VCalendar calendarOptions
             calendar.add event.toIcal()
+
             icsPath = path.join os.tmpdir(), 'invite.ics'
             fs.writeFile icsPath, calendar.toString(), (err) ->
                 if (err)


### PR DESCRIPTION
This should fix https://github.com/cozy/cozy-calendar/issues/383.