### PR TITLE
Move settings button to header + fixes

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -63,5 +63,7 @@ module.exports =
         Object.freeze this if typeof Object.freeze is 'function'
 
     isMobile: ->
-        return $(window).width() <= 600
+        test = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
+            .test(navigator.userAgent)
+        return test or $(window).width() <= 600
 

--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -63,7 +63,7 @@ module.exports =
         Object.freeze this if typeof Object.freeze is 'function'
 
     isMobile: ->
-        test = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
+        return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i
             .test(navigator.userAgent)
-        return test or $(window).width() <= 600
+
 

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -28,7 +28,7 @@ module.exports = class Router extends Backbone.Router
         # Only listview on mobile devices.
         $(window).resize =>
             if window.app.isMobile()
-                @navigate 'list', trigger:true
+                @navigate 'list', trigger: true
 
     navigate: (route, options) ->
         # Only listview on mobile devices.

--- a/client/app/views/calendar_header.coffee
+++ b/client/app/views/calendar_header.coffee
@@ -3,7 +3,7 @@ BaseView = require '../lib/base_view'
 
 module.exports = class CalendarHeader extends BaseView
 
-    tagName: 'table'
+    tagName: 'div'
     id: 'calendarHeader'
     className: 'fc-header'
     template: require './templates/calendar_header'

--- a/client/app/views/calendar_view.coffee
+++ b/client/app/views/calendar_view.coffee
@@ -102,18 +102,18 @@ module.exports = class CalendarView extends BaseView
 
 
     handleWindowResize: (initial) =>
+
         if $(window).width() > 1000
-            targetHeight = $(window).height() - 75
-            $("#menu").height targetHeight + 90
+            targetHeight = $(window).height() - 85
+
         else if $(window).width() > 600
             targetHeight = $(window).height() - 100
-            $("#menu").height targetHeight + 100
+
         else
             targetHeight = $(window).height() - 50
-            $("#menu").height 40
 
-        unless initial is 'initial'
-            @cal.fullCalendar 'option', 'height', targetHeight
+        @cal.fullCalendar 'option', 'height', targetHeight
+
 
     refresh: (collection) ->
         @cal.fullCalendar 'refetchEvents'

--- a/client/app/views/styles/_calendar.styl
+++ b/client/app/views/styles/_calendar.styl
@@ -16,7 +16,6 @@ input-color   = #555
 .fc-view-container
     clear:none
     padding 0.5em 1em
-    height 100%
 
     thead
         tr
@@ -92,6 +91,13 @@ input-color   = #555
             text-decoration none
             cursor default
 
+        &.btn-settings
+            i
+                margin-right 0.4em
+
+            &:hover
+                i
+                    text-decoration none
 
     .fc-button
         margin 0
@@ -206,6 +212,8 @@ td.fc-widget-header
     border-color: #DDD
 
 #alarms
+    height 100%
+
     thead
         .fc-first
             .fc-day-header

--- a/client/app/views/styles/_menu.styl
+++ b/client/app/views/styles/_menu.styl
@@ -191,10 +191,6 @@
                     &:hover
                         opacity 1
 
-    .btn-settings
-        width calc(200px - 2em)
-        padding 0.4em 0.8em
-        box-sizing border-box
 
 .color-picker
     margin 0 1em

--- a/client/app/views/styles/application.styl
+++ b/client/app/views/styles/application.styl
@@ -85,6 +85,9 @@ h3
         height 1.2rem
         border-radius 100%
 
+    .dayprogram:first-child
+        margin-top 2em 
+
 .active.btn
     background: blue - 20%
     box-shadow: 1px 3px 2px rgba(0, 0, 0, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.0)

--- a/client/app/views/templates/calendar_header.jade
+++ b/client/app/views/templates/calendar_header.jade
@@ -17,4 +17,7 @@ img.hidden(src="img/spinner-white.svg")
         span.btn.fc-button-month(class=active('month') type="button")= t('month')
         span.btn.fc-button-week(class=active('week') type="button")= t('week')
         span.btn.fc-button-list(class=active('list') type="button")= t('list')
-
+    .btn-group(role="group")
+        a.btn.btn-settings(href="#settings")
+            i.fa.fa-cog
+            span= t('sync settings button label')

--- a/client/app/views/templates/menu.jade
+++ b/client/app/views/templates/menu.jade
@@ -8,7 +8,4 @@ li.calendars
 
 ul#menuitems
 
-a.btn.btn-settings.stick-bottom(href="#settings")
-    i.fa.fa-cog
-    span= t('sync settings button label')
 


### PR DESCRIPTION
I moved settings button to the header because it had a weird behavior when browsing calendar months.

It was the opportunity to fix regressions I added with my previous changes.
