### PR TITLE
Fix update email were not sent to guests in one case

### DIFF
--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -320,8 +320,9 @@ module.exports = class ScheduleItem extends Backbone.Model
                 return guest.status in ['ACCEPTED', 'NEEDS-ACTION']
 
             else if method in ['update', 'patch']
-                return guest.status is 'INVITATION-NOT-SENT' or (
-                    guest.status is 'ACCEPTED' and @startDateChanged)
+                return guest.status is 'INVITATION-NOT-SENT' or \
+                       guest.status is 'NEEDS-ACTION' or \
+                       (guest.status is 'ACCEPTED' and @startDateChanged)
 
         .map (guest) -> guest.email
 


### PR DESCRIPTION
When invitation email has been sent, but guests didn't accept or reject the
invitation, changing the event would not trigger an update email.

@aenario could we please merge and publish this commit? Reason is @Benibur asking for it in emergency.