### PR TITLE
Fix function scope to use @ in closure

### DIFF
--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -312,7 +312,7 @@ module.exports = class ScheduleItem extends Backbone.Model
 
         # else: look state of each guest.
         attendees = @get('attendees') or []
-        guestsToInform = attendees.filter (guest) ->
+        guestsToInform = attendees.filter (guest) =>
             if method is 'create'
                 return true
 


### PR DESCRIPTION
In the closure's scope, we use "@" to reference parent's scope, without using the fat arrow.