### PR TITLE
Fix event import

### DIFF
--- a/client/app/views/import_view.coffee
+++ b/client/app/views/import_view.coffee
@@ -83,6 +83,10 @@ module.exports = class ImportView extends BaseView
     # Show the event preview list. It doesn't display all events at the same
     # time because Firefox cannot handle it and freezes.
     showEventsPreview: (events) ->
+        # The ics file may contain events with duplicate ID that won't be added
+        # to the collection but will be imported, so we can't rely on eventList
+        # length for the total number of events to import
+        @eventsCount = events.length
         # Break event to import in smaller lists
         @eventLists = helpers.getLists events, 100
 
@@ -176,13 +180,12 @@ module.exports = class ImportView extends BaseView
 
     # Set import counter to 0.
     initCounter: ->
-        total = @eventList.collection.length
         @counter = 0
 
         # Set the progress widget
         $('.import-progress').html """
         <p>#{t 'imported events'}:
-            <span class="import-counter">0</span>/#{total}</p>
+            <span class="import-counter">0</span>/#{@eventsCount}</p>
         """
 
     # Update counter current value.

--- a/client/app/views/import_view.coffee
+++ b/client/app/views/import_view.coffee
@@ -88,7 +88,10 @@ module.exports = class ImportView extends BaseView
         # length for the total number of events to import
         @eventsCount = events.length
         # Break event to import in smaller lists
-        @eventLists = helpers.getLists events, 100
+        # Reduced the number to 50 because sometime the request was too big
+        # and some events not imported
+        @eventLists  = helpers.getLists events, 50
+        window.eventList = @eventList
 
         async.eachSeries @eventLists, (eventList, done) =>
             @eventList.collection.add eventList, sort: false

--- a/client/app/views/menu.coffee
+++ b/client/app/views/menu.coffee
@@ -34,7 +34,6 @@ module.exports = class MenuView extends ViewCollection
         # check if a calendar with this name already exists
         checkCalendar = ->
             @tag = app.tags.getOrCreateByName name
-            console.log @tag
 
             calendar = app.calendars.find (tag) ->
                 localName = t name


### PR DESCRIPTION
A user had problem importing a huge ics file: some event weren't imported.
We import events by batches of 100, but some requests were too heavy and some events were not imported.
I reduced the size of the batches to 50 and everything seems to work now.
