### PR TITLE
Fix the description field focus issue in event popover.

### DIFF
--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -55,8 +55,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
 
         # Screen switches.
         'click .input-people': -> @switchToScreen('guests')
-        'click .input-details-row': -> @switchToScreen('details')
-        'click .input-details-trigger': -> @switchToScreen('details')
+        'click .input-details': -> @switchToScreen('details')
         'click .input-alert': -> @switchToScreen('alert')
         'click .input-repeat': -> @switchToScreen('repeat')
 
@@ -96,6 +95,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
             end:         @model.getEndDateObject().add(endOffset, 'd')
             alerts: @model.get('alarms')
             guestsButtonText: @getGuestsButtonText()
+            detailsButtonText: @getDetailsButtonText()
             buttonText: @getButtonText()
             recurrenceButtonText: @getRecurrenceButtonText()
 
@@ -112,6 +112,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
         @duplicateButton = @$ '.duplicate'
         @$optionalFields = @$ '[data-optional="true"]'
         @$moreDetailsButton = @$ '.advanced-link'
+        @$detailsButton = @$ '.input-details button'
 
         # If this is a new unsaved event, hide the irrelevant buttons.
         if @model.isNew()
@@ -346,6 +347,9 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
                 smart_count: numOthers
             return t("guests list", options)
 
+    getDetailsButtonText: ->
+        return @model.get('details') or t("placeholder description")
+
 
     getRecurrenceButtonText: ->
         rrule = @model.get('rrule')
@@ -387,9 +391,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
         @$optionalFields.attr 'aria-hidden', false
         @$moreDetailsButton.hide()
         # focus for keyboard navigation
-        setTimeout =>
-            @$('.input-details-trigger').focus()
-        , 100
+        @$detailsButton.focus()
 
 
     # Handle model's change for field `start`

--- a/client/app/views/styles/_popover.styl
+++ b/client/app/views/styles/_popover.styl
@@ -287,7 +287,6 @@
     .advanced-link
         order 3
 
-.input-details-trigger
 .input-place
     overflow      hidden
     text-overflow ellipsis
@@ -525,3 +524,17 @@ ul.alerts
             width 2em
             height 2em
             margin 2em 0
+
+// The .overflow-wrapper span is a additional span added inside a
+// button-full-block button, to allow an expected rendering of the
+// details Button.
+// Otherwise, Chrome displays the content of the button as expected, but in
+// Firefox the text content of the button overflows the button icons.
+.button-full-block .overflow-wrapper
+    width: 16em
+    overflow: hidden
+    text-overflow: ellipsis
+    line-height: 3em
+    display: inline-block
+    height: 3em
+    display: inline-block

--- a/client/app/views/templates/popover_screens/main.jade
+++ b/client/app/views/templates/popover_screens/main.jade
@@ -62,15 +62,13 @@ div.label.label-row.input-people
         span.fa.fa-angle-right
     button.button-full-block(tabindex=8)= guestsButtonText
 
-div.label.label-row.input-details-row(data-optional="true", aria-hidden="#{!showDetailsByDefault}")
+div.label.label-row.input-details(data-optional="true", aria-hidden="#{!showDetailsByDefault}")
     .icon(title=t("placeholder description"))
         span.fa.fa-align-left
     .icon.right
         span.fa.fa-angle-right
-    input.input-details-trigger.input-full-block(tabindex="9",
-                                                 type="text",
-                                                 value=details,
-                                                 placeholder=t("placeholder description"))
+    button.button-full-block(tabindex=9)
+        span.overflow-wrapper= detailsButtonText
 
 div.label.label-row.input-alert(data-optional="true", aria-hidden="#{!showAlertsByDefault}")
     .icon(title=t("alert tooltip"))

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "coffeelint": "1.15.0",
     "jade2commonjs": "0.1.0",
     "mocha": "2.4.5",
+    "nodemon": "1.9.1",
+    "npm-run-all": "1.7.0",
     "request-json": "0.5.5",
     "should": "8.3.0"
   },
@@ -62,7 +64,9 @@
     "copy:locales": "mkdir -p build/client/app/locales && cp -r client/app/locales/*.json build/client/app/locales/",
     "copy:emails": "cp -r server/mails/ build/server && rm build/server/mails/*.coffee",
     "prewatch:client": "npm run ensure:client",
+    "watch:server": "nodemon --debug --ignore client/ server.coffee",
     "watch:client": "cd client && ../node_modules/.bin/brunch watch",
+    "watch": "npm-run-all --parallel 'watch:*'",
     "clean": "rm -rf build && rm -rf client/public",
     "tx": "tx pull --all || true"
   },


### PR DESCRIPTION
As the description input was having the focus, the screen change to the
"full" description screen was not triggered. Because the presence of the input
was the real problem, causing conflict between the native behavior and the
expected behavior, I replaced it by a full block button. I added a span into
this button to avoid overflow issue in Firefox.


*Remark :*
I removed a timeout added by @clochix in commit
5756690ce46952d3d798e6d5d198c4ea4edc09fc related issue #401.
For me there was no reason to add a timeout here, but maybe I am missing a
point.