### PR TITLE
Keep the model unchanged until the user hits the save button.

### DIFF
--- a/client/app/lib/popover_screen_view.coffee
+++ b/client/app/lib/popover_screen_view.coffee
@@ -17,7 +17,10 @@ module.exports = class PopoverScreenView extends Backbone.View
         console.log 'Warning, no template has been defined for content.'
 
 
-    constructor: (options) ->
+    constructor: (options, context) ->
+        # Retrieve context given by parent popover view
+        @context = context
+
         super(options)
 
         # Check that mandatory options are defined.

--- a/client/app/lib/popover_view.coffee
+++ b/client/app/lib/popover_view.coffee
@@ -9,6 +9,8 @@ module.exports = class PopoverView extends BaseView
         @parentView = options.parentView
         @$tabCells = $ '.fc-day-grid-container'
         @$tabCells = $ '.fc-time-grid-container' if @$tabCells.length is 0
+        # Context passed to all children popover screens
+        @context = {}
 
         return @
 
@@ -69,7 +71,8 @@ module.exports = class PopoverView extends BaseView
             el: @$popover
             titleElement: @titleElement
             contentElement: @contentElement
-            popover: @
+            popover: @,
+            @context
 
         # Render it.
         @screen.render()

--- a/client/app/views/calendar_popover_screen_event.coffee
+++ b/client/app/views/calendar_popover_screen_event.coffee
@@ -1,0 +1,8 @@
+PopoverScreenView = require 'lib/popover_screen_view'
+
+# Export the formModel property for all Event Popover Screens
+module.exports = class EventPopoverScreenView extends PopoverScreenView
+
+    initialize: ->
+        super()
+        @formModel = @context.formModel

--- a/client/app/views/popover_screens/alert.coffee
+++ b/client/app/views/popover_screens/alert.coffee
@@ -1,4 +1,4 @@
-EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event'
 helpers = require 'helpers'
 
 module.exports = class AlertPopoverScreen extends EventPopoverScreenView

--- a/client/app/views/popover_screens/alert.coffee
+++ b/client/app/views/popover_screens/alert.coffee
@@ -1,7 +1,7 @@
-PopoverScreenView = require 'lib/popover_screen_view'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
 helpers = require 'helpers'
 
-module.exports = class AlertPopoverScreen extends PopoverScreenView
+module.exports = class AlertPopoverScreen extends EventPopoverScreenView
 
     # Define the available options to create alerts.
     # Key is the unit M: minute, H: hour, D: day, and W: week
@@ -35,7 +35,7 @@ module.exports = class AlertPopoverScreen extends PopoverScreenView
     getRenderData: ->
 
         # Override the screen title based on the model's value.
-        alerts = @model.get('alarms') or []
+        alerts = @formModel.get('alarms') or []
         numAlerts = alerts.length
         if numAlerts > 0
             @screenTitle = t('screen alert title', smart_count: numAlerts)
@@ -50,7 +50,7 @@ module.exports = class AlertPopoverScreen extends PopoverScreenView
 
         return _.extend super(),
             alertOptions: formattedAlertOptions
-            alerts: @model.get('alarms')
+            alerts: @formModel.get('alarms')
 
 
     afterRender: ->
@@ -60,7 +60,7 @@ module.exports = class AlertPopoverScreen extends PopoverScreenView
         $alerts.empty()
 
         # Create a list item for each alert.
-        alarms = @model.get('alarms') or []
+        alarms = @formModel.get('alarms') or []
         for alarm, index in alarms
             trigger = helpers.iCalDurationToUnitValue alarm.trigg
             {translationKey, value} = @getAlertTranslationInfo trigger
@@ -82,9 +82,9 @@ module.exports = class AlertPopoverScreen extends PopoverScreenView
         index = @$(event.target).parents('li').attr 'data-index'
 
         # Remove the alert.
-        alerts = @model.get('alarms') or []
+        alerts = @formModel.get('alarms') or []
         alerts.splice index, 1
-        @model.set 'alarms', alerts
+        @formModel.set 'alarms', alerts
 
         # Inefficient way to refresh the list, but it's okay since it will never
         # be a big list.
@@ -104,7 +104,7 @@ module.exports = class AlertPopoverScreen extends PopoverScreenView
         index = checkbox.parents('li').attr 'data-index'
 
         # Get current action.
-        alerts = @model.get 'alarms'
+        alerts = @formModel.get 'alarms'
         currentAction = alerts[index].action
 
         # If two actions are selected, unselect this one.
@@ -122,7 +122,7 @@ module.exports = class AlertPopoverScreen extends PopoverScreenView
         # Update the alert only if it has changed.
         if newAction?
             alerts[index].action = newAction
-            @model.set 'alarms', alerts
+            @formModel.set 'alarms', alerts
 
 
     # Handle new alert.
@@ -137,12 +137,12 @@ module.exports = class AlertPopoverScreen extends PopoverScreenView
             triggerValue = helpers.unitValuesToiCalDuration alertOption
 
             # Add it to the list of alarms.
-            alarms = @model.get('alarms') or []
+            alarms = @formModel.get('alarms') or []
             alarms.push
                 action: 'DISPLAY'
                 trigg: triggerValue
 
-            @model.set 'alarms', alarms
+            @formModel.set 'alarms', alarms
 
             # Reset selected value
             @$('select.new-alert').val(-1)

--- a/client/app/views/popover_screens/details.coffee
+++ b/client/app/views/popover_screens/details.coffee
@@ -1,6 +1,6 @@
-PopoverScreenView = require 'lib/popover_screen_view'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
 
-module.exports = class DetailsPopoverScreen extends PopoverScreenView
+module.exports = class DetailsPopoverScreen extends EventPopoverScreenView
 
     screenTitle: t('screen description title')
     templateContent: require 'views/templates/popover_screens/details'
@@ -14,4 +14,4 @@ module.exports = class DetailsPopoverScreen extends PopoverScreenView
     # Save the value when the screen is left.
     onLeaveScreen: ->
         value = @$('.input-details').val()
-        @model.set 'details', value
+        @formModel.set 'details', value

--- a/client/app/views/popover_screens/details.coffee
+++ b/client/app/views/popover_screens/details.coffee
@@ -1,4 +1,4 @@
-EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event'
 
 module.exports = class DetailsPopoverScreen extends EventPopoverScreenView
 

--- a/client/app/views/popover_screens/guests.coffee
+++ b/client/app/views/popover_screens/guests.coffee
@@ -1,4 +1,4 @@
-EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event'
 random = require 'lib/random'
 
 module.exports = class GuestPopoverScreen extends EventPopoverScreenView

--- a/client/app/views/popover_screens/guests.coffee
+++ b/client/app/views/popover_screens/guests.coffee
@@ -1,7 +1,7 @@
-PopoverScreenView = require 'lib/popover_screen_view'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
 random = require 'lib/random'
 
-module.exports = class GuestPopoverScreen extends PopoverScreenView
+module.exports = class GuestPopoverScreen extends EventPopoverScreenView
 
     screenTitle: ''
     templateContent: require 'views/templates/popover_screens/guests'
@@ -13,11 +13,10 @@ module.exports = class GuestPopoverScreen extends PopoverScreenView
         "click .guest-delete": "onRemoveGuest"
         'keyup input[name="guest-name"]': "onKeyup"
 
-
     getRenderData: ->
 
         # Override the screen title based on the model's value.
-        guests = @model.get('attendees') or []
+        guests = @formModel.get('attendees') or []
         numGuests = guests.length
         if numGuests > 0
             @screenTitle = t('screen guest title', smart_count: numGuests)
@@ -25,7 +24,7 @@ module.exports = class GuestPopoverScreen extends PopoverScreenView
             @screenTitle = t('screen guest title empty')
 
         return _.extend super(),
-            guests: @model.get('attendes') or []
+            guests: @formModel.get('attendes') or []
 
 
     afterRender: ->
@@ -35,7 +34,7 @@ module.exports = class GuestPopoverScreen extends PopoverScreenView
         $guests.empty()
 
         # Create a list item for each alert.
-        guests = @model.get('attendees') or []
+        guests = @formModel.get('attendees') or []
         for guest, index in guests
             options = _.extend guest, {index}
             row = @templateGuestRow guest
@@ -87,9 +86,9 @@ module.exports = class GuestPopoverScreen extends PopoverScreenView
         index = @$(event.target).parents('li').attr 'data-index'
 
         # Remove the guest.
-        guests = @model.get('attendees') or []
+        guests = @formModel.get('attendees') or []
         guests.splice index, 1
-        @model.set 'attendees', guests
+        @formModel.set 'attendees', guests
 
         # Inefficient way to refresh the list, but it's okay since it will never
         # be a big list.
@@ -108,7 +107,7 @@ module.exports = class GuestPopoverScreen extends PopoverScreenView
         # An empty value should not be submitted.
         email = email.trim()
         if email.length > 0
-            guests = @model.get('attendees') or []
+            guests = @formModel.get('attendees') or []
             if not _.findWhere(guests, email: email)
                 # Clone the source array, otherwise it's not considered as
                 # changed because it changes the model's attributes
@@ -118,7 +117,7 @@ module.exports = class GuestPopoverScreen extends PopoverScreenView
                     status: 'INVITATION-NOT-SENT'
                     email: email
                     contactid: contactID
-                @model.set 'attendees', guests
+                @formModel.set 'attendees', guests
 
                 # Inefficient way to refresh the list, but it's okay since
                 # it will never be a big list.

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -68,9 +68,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
         # The goal is to keep the original model unchanged until the save
         # action.
         # @See https://github.com/cozy/cozy-calendar/issues/465
-        @context.formModel = @context.formModel or @model.clone()
-        # shortcut
-        @formModel = @context.formModel
+        @formModel = @context.formModel ?= @model.clone()
 
         # Listen to the model's change to update the view accordingly.
         # `start` and `end` are updated when one changed to prevent overlapping

--- a/client/app/views/popover_screens/repeat.coffee
+++ b/client/app/views/popover_screens/repeat.coffee
@@ -1,4 +1,4 @@
-EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event'
 
 tFormat                 = 'HH:mm'
 dFormat                 = 'DD/MM/YYYY'

--- a/client/app/views/popover_screens/repeat.coffee
+++ b/client/app/views/popover_screens/repeat.coffee
@@ -1,4 +1,4 @@
-PopoverScreenView = require 'lib/popover_screen_view'
+EventPopoverScreenView = require 'views/calendar_popover_screen_event.coffee'
 
 tFormat                 = 'HH:mm'
 dFormat                 = 'DD/MM/YYYY'
@@ -7,7 +7,7 @@ allDayDateFieldFormat   = 'YYYY-MM-DD'
 
 NO_REPEAT = -1
 
-module.exports = class RepeatPopoverScreen extends PopoverScreenView
+module.exports = class RepeatPopoverScreen extends EventPopoverScreenView
 
     inputDateFormat: 'DD/MM/YYYY'
     inputDateDTPickerFormat: 'dd/mm/yyyy'
@@ -28,7 +28,6 @@ module.exports = class RepeatPopoverScreen extends PopoverScreenView
 
 
     getRenderData: ->
-
         data = _.extend super(),
             NO_REPEAT: NO_REPEAT
             weekDays: moment.localeData()._weekdays
@@ -44,10 +43,10 @@ module.exports = class RepeatPopoverScreen extends PopoverScreenView
                 monthlyRepeatBy: 'repeat-day'
 
         # Override default rrule value if the event has a rrule.
-        if @model.has('rrule') and @model.get('rrule').length > 0
+        if @formModel.has('rrule') and @formModel.get('rrule').length > 0
             # Extract rules from the rrule string.
             try
-                rruleOptions = RRule.fromString(@model.get('rrule')).options
+                rruleOptions = RRule.fromString(@formModel.get('rrule')).options
             catch e
                 console.error e
 
@@ -165,13 +164,12 @@ module.exports = class RepeatPopoverScreen extends PopoverScreenView
                 .join ';'
         else
             rruleString = null
-
-        @model.set('rrule', rruleString)
+        @formModel.set('rrule', rruleString)
 
 
     # Build a rrule object from the form fields in the DOM.
     buildRRuleFromDOM: =>
-        start = @model.getStartDateObject()
+        start = @formModel.getStartDateObject()
         RRuleWdays = [RRule.SU, RRule.MO, RRule.TU, RRule.WE,
             RRule.TH, RRule.FR, RRule.SA]
 


### PR DESCRIPTION
Related to https://github.com/cozy/cozy-calendar/issues/465

I used two pretty dirty hacks to achieve this fix.

First, I created a local context in the event popover to be able to keep a temporary model between all the popover screens. This model represents the form's state. It's mapped into the original model when the user hits the save button. Using a cleaner solution should have taken too much time and needed more refactor and more regression tests.

Second, I encountered an issue when creating a new event with attendees. The model who was saved to the server was always empty after the "send emails" confirm dialog. I did not find why the app was behaving like this. So I used a dirty temporary variable to store and "freeze" the model's state during the confirm dialog (see client/app/models/scheduleitem.coffee).

I tried to avoid deep changes in the model or in the popover structure, but I sill made important changes to them. So this PR need a lot of attention and tests. I made a lot of test but I am maybe missing some points.