### PR TITLE
Fix "Add calendar" issue.

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -56,6 +56,11 @@ module.exports =
 
         SocketListener.watch @events
         SocketListener.watch @contacts
+        SocketListener.watch @calendars
+
+        if window.initcalendars?
+            @calendars.reset window.initcalendars
+            delete window.initcalendars
 
         if window.inittags?
             @tags.reset window.inittags

--- a/client/app/collections/calendars.coffee
+++ b/client/app/collections/calendars.coffee
@@ -22,20 +22,21 @@ module.exports = class CalendarCollection extends TagCollection
 
 
     resetFromBase: ->
-        @reset []
+        #@reset []
         @eventCollection.each (model) => @onBaseCollectionAdd model
 
 
     onBaseCollectionChange: (model) ->
-        @resetFromBase()
+#        @resetFromBase()
 
 
     onBaseCollectionAdd: (model) ->
         [calendarName, tags...] = model.get 'tags'
         calendar = app.tags.getOrCreateByName calendarName
-        @add calendar
+        #@add calendar
 
         if calendar.isNew()
+            @add calendar
             app.tags.add calendar
             calendar.save()
 
@@ -62,6 +63,8 @@ module.exports = class CalendarCollection extends TagCollection
             if err
                 callback t('server error occured')
             else
+                # Effectively removing the calendar
+                super @findWhere name: calendarName
                 callback()
 
 
@@ -69,9 +72,10 @@ module.exports = class CalendarCollection extends TagCollection
     rename: (oldName, newName, callback) ->
         request.post 'events/rename-calendar', {oldName, newName}, (err) ->
             if err
-                callback t('server error occured')
+                console.error t('server error occured'), err
+                callback oldName
             else
-                callback()
+                callback newName
 
 
     toArray: ->

--- a/client/app/collections/calendars.coffee
+++ b/client/app/collections/calendars.coffee
@@ -14,7 +14,6 @@ module.exports = class CalendarCollection extends TagCollection
         @eventCollection = app.events
 
         @listenTo @eventCollection, 'add', @onBaseCollectionAdd
-        @listenTo @eventCollection, 'change:tags', @onBaseCollectionChange
         @listenTo @eventCollection, 'remove', @onBaseCollectionRemove
         @listenTo @eventCollection, 'reset', @resetFromBase
 
@@ -22,18 +21,12 @@ module.exports = class CalendarCollection extends TagCollection
 
 
     resetFromBase: ->
-        #@reset []
         @eventCollection.each (model) => @onBaseCollectionAdd model
-
-
-    onBaseCollectionChange: (model) ->
-#        @resetFromBase()
 
 
     onBaseCollectionAdd: (model) ->
         [calendarName, tags...] = model.get 'tags'
         calendar = app.tags.getOrCreateByName calendarName
-        #@add calendar
 
         if calendar.isNew()
             @add calendar

--- a/client/app/collections/scheduleitems.coffee
+++ b/client/app/collections/scheduleitems.coffee
@@ -8,7 +8,7 @@ module.exports = class ScheduleItemsCollection extends Backbone.Collection
     # to check every event calendar in the a given calendars collection
     # to verify the visibility
     visibleItems: (calendars) ->
-        return _ @filter (item) ->
+        new ScheduleItemsCollection @filter (item) ->
             calendar = calendars.get item.getCalendar()?.get('id')
             return calendar?.get 'visible'
 

--- a/client/app/collections/scheduleitems.coffee
+++ b/client/app/collections/scheduleitems.coffee
@@ -3,18 +3,26 @@ module.exports = class ScheduleItemsCollection extends Backbone.Collection
     model: require '../models/scheduleitem'
     comparator: (si1, si2) -> si1.getDateObject().diff si2.getDateObject()
 
+    # The calendar tag for all event was referencing the same instance
+    # in every event object. This is not the case anymore, so we have
+    # to check every event calendar in the a given calendars collection
+    # to verify the visibility
+    visibleItems: (calendars) ->
+        return _ @filter (item) ->
+            calendar = calendars.get item.getCalendar()?.get('id')
+            return calendar?.get 'visible'
+
+
     getFCEventSource: (calendars) =>
         return (start, end, timezone, callback) =>
             # start and end : ambiguous moments
             # only dates if month or week view.
             eventsInRange = []
-            @each (item) ->
+
+            @visibleItems(calendars)?.each (item) ->
                 itemStart = item.getStartDateObject()
                 itemEnd = item.getEndDateObject()
                 duration = itemEnd - itemStart
-
-                calendar = item.getCalendar()
-                return null if calendar and calendar.get('visible') is false
 
                 if item.isRecurrent()
                     try

--- a/client/app/lib/popover_view.coffee
+++ b/client/app/lib/popover_view.coffee
@@ -9,8 +9,6 @@ module.exports = class PopoverView extends BaseView
         @parentView = options.parentView
         @$tabCells = $ '.fc-day-grid-container'
         @$tabCells = $ '.fc-time-grid-container' if @$tabCells.length is 0
-        # Context passed to all children popover screens
-        @context = {}
 
         return @
 

--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -15,16 +15,24 @@ module.exports = class ScheduleItem extends Backbone.Model
         @on 'change:' + @startDateField, => @startDateChanged = true
         @on 'change:attendees', => @attendeesChanged = true
 
+
     # Return the Tag object of the calendar tag of this.
     getCalendar: ->
-        return app.tags.getByName @get('tags')?[0]
+        # TODO : Should not call app in a model, quick fix.
+        return @calendar or app.calendars.getByName @get('tags')?[0]
 
-    setCalendar: (cal) ->
+    setCalendar: (calendar) ->
         # we clone the source array, otherwise it's not considered as changed
         # because it changes the model's attributes
         oldTags = @get 'tags'
         tags = if oldTags? then [].concat(oldTags) else []
-        tags[0] = cal
+        tags[0] = calendar.get 'name'
+
+
+        # @calendar = calendar
+
+        @calendar = calendar
+
         @set tags: tags
 
     getDefaultColor: -> 'grey'

--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -28,9 +28,6 @@ module.exports = class ScheduleItem extends Backbone.Model
         tags = if oldTags? then [].concat(oldTags) else []
         tags[0] = calendar.get 'name'
 
-
-        # @calendar = calendar
-
         @calendar = calendar
 
         @set tags: tags

--- a/client/app/views/calendar_popover_event.coffee
+++ b/client/app/views/calendar_popover_event.coffee
@@ -43,7 +43,16 @@ module.exports = class EventPopOver extends PopoverView
                 description: ''
                 place: ''
 
-        @listenToOnce @model, 'change', =>
+        # Context passed to all children popover screens
+        @context = {}
+
+        # The formModel represents the form's state. It's synchronized with
+        # the original model just before the save action.
+        # The formModel is passed to popover screens via the context property
+        # @See https://github.com/cozy/cozy-calendar/issues/465
+        @context.formModel = @model.clone();
+
+        @listenToOnce @context.formModel, 'change', =>
             @modelHasChanged = true
 
         super options

--- a/client/app/views/calendar_view.coffee
+++ b/client/app/views/calendar_view.coffee
@@ -24,7 +24,7 @@ module.exports = class CalendarView extends BaseView
         @model = null
 
         @calendarsCollection = app.calendars
-        @listenTo @calendarsCollection, 'change', @refresh
+        @listenTo @calendarsCollection, 'change', @onCalendarCollectionChange
 
 
     afterRender: ->
@@ -135,6 +135,9 @@ module.exports = class CalendarView extends BaseView
         @cal.fullCalendar 'refetchEvents'
 
 
+    onCalendarCollectionChange: (collection) ->
+        @refresh collection
+
     onRemove: (model) ->
         @cal.fullCalendar 'removeEvents', model.cid
 
@@ -157,6 +160,10 @@ module.exports = class CalendarView extends BaseView
         if fcEvent?
             _.extend fcEvent, data
             @cal.fullCalendar 'updateEvent', fcEvent
+
+        # Refresh to deal with calendar update.
+        # If the new calendar is not visible the event should not be shown
+        @refresh()
 
 
     showPopover: (options) ->

--- a/client/app/views/menu.coffee
+++ b/client/app/views/menu.coffee
@@ -69,6 +69,8 @@ module.exports = class MenuView extends ViewCollection
         calendarEvent.save null,
             wait: true
             success: ->
+                # TODO: All this should be in CalendarCollection
+                app.calendars.add app.tags.getOrCreateByName name
                 # wait for the newly created calendar to appear in the DOM
                 wait = setInterval ->
                     newCalSel = """

--- a/client/app/views/menu_item.coffee
+++ b/client/app/views/menu_item.coffee
@@ -102,7 +102,7 @@ module.exports = class MenuItemView extends BaseView
             trashButton.removeClass 'hidden'
 
 
-    onCalendarChange: =>
+    onCalendarChange: ->
         # Update the label after a rename
         if @rawTextElement and @model.hasChanged 'name'
             @rawTextElement.html @model.get 'name'

--- a/client/app/views/menu_item.coffee
+++ b/client/app/views/menu_item.coffee
@@ -22,6 +22,11 @@ module.exports = class MenuItemView extends BaseView
         'keyup input.calendar-name': 'onRenameValidation'
 
 
+    initialize: ->
+        super()
+        @listenTo @model, 'change', @onCalendarChange
+
+
     getRenderData: ->
         label: @model.get 'name'
         colorSet: colorSet
@@ -97,6 +102,15 @@ module.exports = class MenuItemView extends BaseView
             trashButton.removeClass 'hidden'
 
 
+    onCalendarChange: =>
+        # Update the label after a rename
+        if @rawTextElement and @model.hasChanged 'name'
+            @rawTextElement.html @model.get 'name'
+
+        if @model.hasChanged 'color'
+            @model.save()
+
+
     # Handle `blur` and `keyup` (`enter` and `esc` keys) events in order to
     # rename a calendar.
     onRenameValidation: (event) ->
@@ -108,14 +122,16 @@ module.exports = class MenuItemView extends BaseView
         # `escape` key cancels the edition.
         if key is 27
 
-            @hideInput input, calendarName
+            @hideInput input
 
         # `blur` event and `enter` key trigger the persistence
         else if (key is 13 or event.type is 'focusout')
             @showLoading()
-            app.calendars.rename calendarName, input.val(), =>
+            app.calendars.rename calendarName, input.val(), (name) =>
+                @model.set 'name', name
+                @model.set 'color', ColorHash.getColor(name, 'color')
                 @hideLoading()
-                @hideInput input, calendarName
+                @hideInput input
         else
             @buildBadge ColorHash.getColor(input.val(), 'color')
 
@@ -160,7 +176,7 @@ module.exports = class MenuItemView extends BaseView
         @rawTextElement.insertAfter @$('.badge')
 
         # Restores the badge color
-        @buildBadge calendarName
+        @buildBadge @model.get 'color'
 
         # Shows the menu again
         @$('.dropdown-toggle').show()

--- a/client/app/views/popover_screens/details.coffee
+++ b/client/app/views/popover_screens/details.coffee
@@ -15,3 +15,6 @@ module.exports = class DetailsPopoverScreen extends EventPopoverScreenView
     onLeaveScreen: ->
         value = @$('.input-details').val()
         @formModel.set 'details', value
+
+    getRenderData: ->
+        return details: @formModel.get 'details'

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -62,15 +62,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
         'click .input-repeat': -> @switchToScreen('repeat')
 
     initialize: ->
-        # As we are in the main event popover screen, we initialize the
-        # form model.
-        # If we're comming back from another screen, the formModel already
-        # exists.
-        # If not, we create a new one by cloning the original model.
-        # The goal is to keep the original model unchanged until the save
-        # action.
-        # @See https://github.com/cozy/cozy-calendar/issues/465
-        @formModel = @context.formModel ?= @model.clone()
+        @formModel = @context.formModel
 
         # Listen to the model's change to update the view accordingly.
         # `start` and `end` are updated when one changed to prevent overlapping

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -329,7 +329,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
             saveEvent = () =>
                 @model.save @formModel.attributes,
                 wait: true
-                success: (model) =>
+                success: (model) ->
                     app.events.add model, sort: false
                 error: ->
                     # TODO better error handling
@@ -341,7 +341,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
             if calendar.isNew()
                 calendar.save calendar.attributes,
                     wait: true
-                    success: =>
+                    success: ->
                         app.calendars.add calendar
                         saveEvent()
                     error: ->

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -115,6 +115,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
         @$el.attr 'tabindex', 0
 
         # Cache jQuery selectors.
+        @description = @$ '.input-desc'
         @$container   = @$ '.popover-content-wrapper'
         @$addButton    = @$ '.btn.add'
         @removeButton = @$ '.remove'
@@ -154,6 +155,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
 
         @calendarComboBox.on 'edition-complete', (value) =>
             @formModel.setCalendar app.calendars.getOrCreateByName value
+            @description.focus()
 
         # Apply the expanded status if it has been previously set.
         if window.popoverExtended

--- a/client/app/views/widgets/combobox.coffee
+++ b/client/app/views/widgets/combobox.coffee
@@ -101,7 +101,7 @@ module.exports = class ComboBox extends BaseView
 
 
     onKeyUp: (ev, ui) =>
-        if event.keyCode is 13 or event.which is 13 #ENTER
+        if ev.keyCode is 13 or ev.which is 13 #ENTER
             @onSubmit ev, ui
         else
             @onChange ev, ui

--- a/client/app/views/widgets/combobox.coffee
+++ b/client/app/views/widgets/combobox.coffee
@@ -5,7 +5,7 @@ Tag = require 'models/tag'
 module.exports = class ComboBox extends BaseView
 
     events:
-        'keyup': 'onChange'
+        'keyup': 'onKeyUp'
         'keypress': 'onChange'
         'change': 'onChange'
         'blur': 'onBlur'
@@ -16,14 +16,8 @@ module.exports = class ComboBox extends BaseView
 
         @source = options.source
 
-        @$el.autocomplete
-            delay: 0
-            minLength: 0
-            source: @source
-            close: @onClose
-            open: @onOpen
-            select: @onSelect
-        @$el.addClass 'combobox'
+        @resetComboBox options.source
+
         @small = options.small
 
         @autocompleteWidget = @$el.data 'ui-autocomplete'
@@ -42,6 +36,18 @@ module.exports = class ComboBox extends BaseView
 
         value = options.current or @getDefaultValue()
         @onEditionComplete value
+
+
+    # Used for initialization or reset
+    resetComboBox: (source) ->
+        @$el.autocomplete
+            delay: 0
+            minLength: 0
+            source: source
+            close: @onClose
+            open: @onOpen
+            select: @onSelect
+        @$el.addClass 'combobox'
 
 
     openMenu: =>
@@ -94,9 +100,21 @@ module.exports = class ComboBox extends BaseView
         @trigger 'edition-complete', ui?.item?.value or @value()
 
 
+    onKeyUp: (ev, ui) =>
+        if event.keyCode is 13 or event.which is 13 #ENTER
+            @onSubmit ev, ui
+        else
+            @onChange ev, ui
+
+
+    onSubmit: (ev, ui) =>
+        ev.stopPropagation()
+        @onSelect ev, ui
+
+
     onEditionComplete: (name) =>
-        @tag = app.tags.getOrCreateByName name
-        @buildBadge @tag.get('color')
+        @calendar = app.calendars.getOrCreateByName name
+        @buildBadge @calendar.get('color')
 
 
     onChange: (ev, ui) =>

--- a/server/controllers/index.coffee
+++ b/server/controllers/index.coffee
@@ -21,6 +21,7 @@ module.exports.index = (req, res, next) ->
             done null, contacts
 
         (cb) -> Tag.byName {}, cb
+        (cb) -> Event.calendars cb
         # Load only reccuring events and events close to current day (> -3
         # months and < +3 months). That way it doesn't load too much events.
         (cb) ->
@@ -49,7 +50,7 @@ module.exports.index = (req, res, next) ->
 
 
         [
-            contacts, tags, events, instance, webDavAccount, timezone
+            contacts, tags, calendars, events, instance, webDavAccount, timezone
         ] = results
 
         locale = instance?.locale or 'en'
@@ -68,6 +69,7 @@ module.exports.index = (req, res, next) ->
         res.render 'index', imports: """
             window.locale = "#{locale}";
             window.inittags = #{sanitize tags};
+            window.initcalendars = #{sanitize calendars};
             window.initevents = #{sanitize events}
             window.initcontacts = #{sanitize contacts};
             window.webDavAccount = #{sanitize webDavAccount};

--- a/server/controllers/tags.coffee
+++ b/server/controllers/tags.coffee
@@ -23,7 +23,7 @@ module.exports.read = (req, res) ->
 
 module.exports.create = (req, res) ->
     data = req.body
-    Tag.getOrCreate data, (err, tag) ->
+    Tag.getOrCreateByName data, (err, tag) ->
         if err?
             res.send error: "Server error while creating tag.", 500
         else

--- a/server/models/event.coffee
+++ b/server/models/event.coffee
@@ -53,7 +53,6 @@ Event.tags = (callback) ->
 
 Event.calendars = (callback) ->
     Event.tags (err, results) ->
-        console.log results.calendar
         return callback err, [] if err
 
         async.map results.calendar,
@@ -62,7 +61,6 @@ Event.calendars = (callback) ->
                 return Tag.getOrCreateByName name: calendarName, cb
             ,
             (err, calendars) ->
-                console.log 'callback', calendars
                 callback null, calendars
 
 

--- a/server/models/event.coffee
+++ b/server/models/event.coffee
@@ -3,6 +3,7 @@ moment = require 'moment-timezone'
 async = require 'async'
 log = require('printit')
     prefix: 'event:model'
+Tag = require './tag'
 
 localization = require '../libs/localization_manager'
 User = require './user'
@@ -48,6 +49,21 @@ Event.tags = (callback) ->
             [type, tag] = result.key
             out[type].push tag
         callback null, out
+
+
+Event.calendars = (callback) ->
+    Event.tags (err, results) ->
+        console.log results.calendar
+        return callback err, [] if err
+
+        async.map results.calendar,
+            # Map string to tag-compatible object
+            (calendarName, cb) ->
+                return Tag.getOrCreateByName name: calendarName, cb
+            ,
+            (err, calendars) ->
+                console.log 'callback', calendars
+                callback null, calendars
 
 
 Event.createOrGetIfImport = (data, callback) ->

--- a/server/models/tag.coffee
+++ b/server/models/tag.coffee
@@ -9,7 +9,7 @@ module.exports = Tag = cozydb.getModel 'Tag',
 Tag.byName = (options, callback) ->
     Tag.request 'byName', options, callback
 
-Tag.getOrCreate = (data, callback) ->
+Tag.getOrCreateByName = (data, callback) ->
     # Name is a primary key.
     Tag.byName key: data.name, (err, tags)->
         if err


### PR DESCRIPTION
This PR brings a huge change in the way of building the calendar list.

This list is not built anymore with tags set on the timeframe events, but it's
loaded directly server side. We were not able to check all the existing calendar
since all the events were not loaded anymore.

So, this new method implies a lot of changes, like :

* Event filtering (visible or not)
* Calendar update (name/color)
* Calendar deletion
* Sync with event models
* Calendar update in the popover
* Calendar creation in the popover

Also, this PR fixes a regression between two previous fixes : The confirm dialog
when closing the event popover was not shown since the creation of a formModel
property, dedicated to reprensent the form state. The original model was
permanently computed as "unchanged".