### PR TITLE
Fix error due to mediatype being undefined

### DIFF
--- a/server/models/contact.coffee
+++ b/server/models/contact.coffee
@@ -25,7 +25,7 @@ Contact::asNameAndEmails = ->
     # XXX What if several Cozy instances are linked to one user?
     cozy = dp.value for dp in @datapoints when (dp.name is 'other' and
         dp.type is 'COZY') or (dp.name is 'url' and
-        dp.mediatype.search 'cozy' isnt -1)
+        dp.mediatype?.search 'cozy' isnt -1)
 
     return simple =
         id         : @id


### PR DESCRIPTION
I forgot to check for the existence of the field `mediatype` which could make the calendar crash if that is the case. For instance adding an url in the "additionnal informations" subsection could cause this.