### PR TITLE
Handle sharing error at event creation.

### DIFF
--- a/client/app/models/event.coffee
+++ b/client/app/models/event.coffee
@@ -152,7 +152,7 @@ module.exports = class Event extends ScheduleItem
             #   The user is the recipient : a sharing object having the same
             #       shareID property than the event exists.
             error: (sharing, response, options) =>
-                sharingNotFound = response.status == 404
+                sharingNotFound = response and response.status == 404
 
                 if sharingNotFound
                     @fetchSharingByShareId (err, sharing) =>

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -337,8 +337,12 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
             saveEvent = () =>
                 @model.save @formModel.attributes,
                 wait: true
-                success: (model) ->
+                success: (model, response) =>
                     app.events.add model, sort: false
+
+                    isShared = model.get('shareID')?
+                    @onSharedEventSync(model) if isShared
+
                 error: ->
                     # TODO better error handling
                     alert 'server error occured'
@@ -357,6 +361,15 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
                         alert 'server error occured'
             else
                 saveEvent()
+
+    # Fetch the sharing object to handle any error
+    onSharedEventSync: (event) ->
+        event.fetchSharing (err, sharing) =>
+            err = err ?= sharing.error
+            if err
+                console.error err
+                alert 'Sharing with Cozy users failed'
+
 
     handleError: (error) ->
         switch error.field

--- a/server/controllers/sharings.coffee
+++ b/server/controllers/sharings.coffee
@@ -6,14 +6,18 @@ module.exports.all = (req, res) ->
         Sharing.byShareID data.shareID, (err, sharings) ->
             if err
                 res.status(500).send error: "Server error occured"
+            if not sharings?.length
+                res.status(404).send error: "Sharing not found"
             else
                 res.send sharings[0]
     else
         Sharing.all (err, sharings)->
             if err
                 res.status(500).send error: err
+            if not sharings?.length
+                res.status(404).send error: "Sharing not found"
             else
-                res.send sharings
+                res.send sharings[0]
 
 
 module.exports.fetch = (req, res, next, id) ->


### PR DESCRIPTION
At this time the error is just display via an alert message.
We should definetely set up a global error management mechanism for the whole
app.