### PR TITLE
Display close warning on every event popover, whatever the source of the close

### DIFF
--- a/client/app/lib/base_view.coffee
+++ b/client/app/lib/base_view.coffee
@@ -32,3 +32,73 @@ module.exports = class BaseView extends Backbone.View
         view.$(selector).each (index, element) =>
             if element then @setElement element
         @
+
+
+    # Define an handler when a click is performed elsewhere in the document
+    # Typically, to hide a popup or a popover
+    # We pass document as a paramter to be able to easyly test or adapt
+    # this method in the future.
+    addClickOutListener: (document, callback) ->
+
+        # Handler for clicks that are considered outside the element and should
+        # trigger the callback
+        documentClickHandler = (event) =>
+            # the source event property is set in insideElementClickHandler
+            # below.
+            clickIsOutside =
+                (not event.clickOutSources or @ not in event.clickOutSources)
+            if clickIsOutside
+                callback()
+
+        document.addEventListener 'click', documentClickHandler
+
+        # Handler for click that are considered inside the element and should
+        # not trigger the callback
+        insideElementClickHandler = (event) =>
+            event.clickOutSources = event.clickOutSources ?= []
+            event.clickOutSources.push @
+
+        listenedElements = []
+
+        if @$el
+            element = @$el.get(0)
+            element.addEventListener 'click', insideElementClickHandler
+            listenedElements.push element
+
+        # Return an interface to manage the handling afterwards
+        # with methods :
+        #   exceptOn to manage exception
+        #   ignoreEvent to specify an event that should be ignored
+        #   dispose to remove all listeners
+
+        # Specify exceptions that should not be considered as a "click outside"
+        exceptOn: (elements) ->
+            addClickListener = (element) ->
+                if not _.isElement element
+                    throw new Error 'Cannot add click listener on non element'
+                element.addEventListener 'click', insideElementClickHandler
+                listenedElements.push element
+
+            if _.isArray elements
+                elements.forEach addClickListener
+            else
+                addClickListener elements
+
+            # chainable
+            return @
+
+        # Specify event which should be ignored as outside click (for example
+        # the event responsible for popup or popover opening)
+        ignoreEvent: (event) ->
+            if event
+                insideElementClickHandler event
+
+            # chainable
+            return @
+
+        # Clean all listeners
+        dispose: () ->
+            document.removeEventListener 'click', documentClickHandler
+
+            listenedElements.forEach (element) ->
+                element.removeEventListener 'click', insideElementClickHandler

--- a/client/app/lib/popover_view.coffee
+++ b/client/app/lib/popover_view.coffee
@@ -15,12 +15,7 @@ module.exports = class PopoverView extends BaseView
         return @
 
 
-    selfclose: (checkoutChanges = true) ->
-        @parentView.onPopoverClose?()
-        @close(checkoutChanges)
-
-
-    close: ->
+    close: (callback) ->
         if @$popover?
             @$popover.remove()
             @$popover = null
@@ -28,6 +23,7 @@ module.exports = class PopoverView extends BaseView
         @clickOutListener.dispose()
         @remove()
 
+        callback() if callback and typeof callback is 'function'
 
     # Get templates for a given screen.
     getScreen: (screenID = 'default') ->
@@ -41,7 +37,7 @@ module.exports = class PopoverView extends BaseView
 
 
     # Switch screen.
-    switchToScreen: (screenID) ->
+    switchToScreen: (screenID, data) ->
 
         # Throw if popover has not been rendered yet.
         unless @$popover?
@@ -58,11 +54,11 @@ module.exports = class PopoverView extends BaseView
             @screen.destroy()
 
         # Build the screen object and render it.
-        @renderScreen screenID
+        @renderScreen screenID, data
 
 
     # Render a specific screen.
-    renderScreen: (screenID) ->
+    renderScreen: (screenID, data) ->
         # Get the screen data.
         ScreenBuilder = @getScreen screenID
 
@@ -72,14 +68,15 @@ module.exports = class PopoverView extends BaseView
             el: @$popover
             titleElement: @titleElement
             contentElement: @contentElement
-            popover: @,
+            popover: @
+            data : data,
             @context
 
         # Render it.
         @screen.render()
 
         # Change current screen information.
-        @screenElement.attr 'data-screen', screenID
+        @context.screen = screenID
 
 
     render: ->
@@ -97,7 +94,6 @@ module.exports = class PopoverView extends BaseView
             @$popover = $ popoverWrapper
             @titleElement = @$popover.find '.popover-title'
             @contentElement = @$popover.find '.popover-content'
-            @screenElement = @$popover.find '.screen-indicator'
 
             # Reset @el and @$el.
             @setElement @$popover
@@ -117,7 +113,7 @@ module.exports = class PopoverView extends BaseView
     afterRender: ->
         # The click out listener must be set after the rendering of the view,
         # otherwise @$el is not ready
-        @clickOutListener = @addClickOutListener @document, => @selfclose()
+        @clickOutListener = @addClickOutListener @document, => @close()
             .ignoreEvent @openerEvent
             .exceptOn @target.get(0)
 

--- a/client/app/lib/popover_view.coffee
+++ b/client/app/lib/popover_view.coffee
@@ -5,6 +5,8 @@ module.exports = class PopoverView extends BaseView
 
     initialize: (options) ->
         @target = options.target
+        @openerEvent = options.openerEvent
+        @document = options.document
         @container = options.container
         @parentView = options.parentView
         @$tabCells = $ '.fc-day-grid-container'
@@ -23,6 +25,7 @@ module.exports = class PopoverView extends BaseView
             @$popover.remove()
             @$popover = null
         @target.data 'popover', undefined
+        @clickOutListener.dispose()
         @remove()
 
 
@@ -109,6 +112,14 @@ module.exports = class PopoverView extends BaseView
         @positionPopover()
 
         return @
+
+
+    afterRender: ->
+        # The click out listener must be set after the rendering of the view,
+        # otherwise @$el is not ready
+        @clickOutListener = @addClickOutListener @document, => @selfclose()
+            .ignoreEvent @openerEvent
+            .exceptOn @target.get(0)
 
 
     # Set the popover's position so it doesn't overflow out of the screen.

--- a/client/app/lib/popover_view.coffee
+++ b/client/app/lib/popover_view.coffee
@@ -22,7 +22,7 @@ module.exports = class PopoverView extends BaseView
         @target.data 'popover', undefined
         @clickOutListener.dispose()
         @remove()
-
+        @trigger 'closed', @
         callback() if callback and typeof callback is 'function'
 
     # Get templates for a given screen.

--- a/client/app/lib/popup_view.coffee
+++ b/client/app/lib/popup_view.coffee
@@ -7,6 +7,9 @@ module.exports = class PopupView extends BaseView
         super
         @anchor = options.anchor
 
+        @addClickOutListener options.document, => @hide()
+            .exceptOn @anchor.get 0
+
 
     hide: ->
         @$el.hide()

--- a/client/app/models/event.coffee
+++ b/client/app/models/event.coffee
@@ -165,7 +165,6 @@ module.exports = class Event extends ScheduleItem
 
 
     fetchSharingByShareId: (callback) ->
-        console.debug 'Event.fetchSharingByShareId'
         if not @hasSharing()
             callback null, null
             return

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -105,6 +105,7 @@ module.exports = class Router extends Backbone.Router
                 events: app.events
                 # TODO : All router logic should be in app object
                 pendingEventSharingsCollection: app.pendingEventSharings
+            document: window.document
 
         app.menu.activate 'calendar'
         @onCalendar = true

--- a/client/app/views/calendar_view.coffee
+++ b/client/app/views/calendar_view.coffee
@@ -208,14 +208,7 @@ module.exports = class CalendarView extends BaseView
 
         if @popover
             # click on same case
-            if @popover.options? and (@popover.options.model? and \
-               @popover.options.model is options.model or \
-               (@popover.options.start?.isSame(options.start) and \
-               @popover.options.end?.isSame(options.end) and \
-               @popover.options.type is options.type))
-
-                @cal.fullCalendar 'unselect'
-
+            @preventUnselecting()
             @popover.close =>
                 showNewPopover()
 
@@ -263,8 +256,19 @@ module.exports = class CalendarView extends BaseView
             openerEvent: jsEvent.originalEvent
 
 
+    # Prevent unselecting the calendar cell on popover close.
+    # Not the cleanest way but as fullcalendar does not allow us to explicitly
+    # set the selection without trigerring onSelect callback, we have to keep
+    # a flag like this locally.
+    preventUnselecting: ->
+        @isUnselectPrevented = true
+
+
     onPopoverClose: ->
-        @cal.fullCalendar 'unselect'
+        if not @isUnselectPrevented
+            @cal.fullCalendar 'unselect'
+
+        @isUnselectPrevented = false
         @popover = null
 
 

--- a/client/app/views/calendar_view.coffee
+++ b/client/app/views/calendar_view.coffee
@@ -101,22 +101,29 @@ module.exports = class CalendarView extends BaseView
         # Before displaying the calendar for the previous month, we make sure
         # that events are loaded.
         @calHeader.on 'prev', =>
-            monthToLoad = @cal.fullCalendar('getDate').subtract('months', 1)
-            window.app.events.loadMonth monthToLoad, =>
-                @cal.fullCalendar 'prev'
+            @clearViewComponents =>
+                monthToLoad = @cal.fullCalendar('getDate').subtract('months', 1)
+                window.app.events.loadMonth monthToLoad, =>
+                    @cal.fullCalendar 'prev'
 
         # Before displaying the calendar for the next month, we make sure that
         # events are loaded.
         @calHeader.on 'next', =>
-            monthToLoad = @cal.fullCalendar('getDate').add('months', 1)
-            window.app.events.loadMonth monthToLoad, =>
-                @cal.fullCalendar 'next'
+            @clearViewComponents =>
+                monthToLoad = @cal.fullCalendar('getDate').add('months', 1)
+                window.app.events.loadMonth monthToLoad, =>
+                    @cal.fullCalendar 'next'
 
-        @calHeader.on 'today', => @cal.fullCalendar 'today'
-        @calHeader.on 'month', => @cal.fullCalendar 'changeView', 'month'
-        @calHeader.on 'list', ->
-            window.app.events.sort()
-            app.router.navigate 'list', trigger:true
+        @calHeader.on 'today', =>
+            @clearViewComponents =>
+                @cal.fullCalendar 'today'
+        @calHeader.on 'month', =>
+            @clearViewComponents =>
+                @cal.fullCalendar 'changeView', 'month'
+        @calHeader.on 'list', =>
+            @clearViewComponents =>
+                window.app.events.sort()
+                app.router.navigate 'list', trigger:true
         @$('#alarms').prepend @calHeader.render().$el
 
         @handleWindowResize()
@@ -216,18 +223,7 @@ module.exports = class CalendarView extends BaseView
             showNewPopover()
 
 
-
-    # Close the popover, if it's open.
-    closePopover: ->
-        @popover?.close()
-        @onPopoverClose()
-
-
     onChangeView: (view) =>
-
-        # Prevent a popover from staying on screen, if it's open.
-        @closePopover()
-
         @calHeader?.render()
         if @view isnt view.name
             @handleWindowResize()
@@ -237,6 +233,13 @@ module.exports = class CalendarView extends BaseView
         hash = view.intervalStart.format '[month]/YYYY/M'
 
         app.router.navigate hash
+
+
+    clearViewComponents: (callback)->
+        if @popover
+            @popover.close(callback)
+        else
+            callback() if callback and typeof callback is 'function'
 
 
     getUrlHash: =>

--- a/client/app/views/calendar_view.coffee
+++ b/client/app/views/calendar_view.coffee
@@ -29,6 +29,7 @@ module.exports = class CalendarView extends BaseView
 
         @eventSharingButtonView = new EventSharingButtonView
             collection: @model.pendingEventSharingsCollection
+            document: @options.document
 
         @model = null
 
@@ -248,6 +249,8 @@ module.exports = class CalendarView extends BaseView
             start: start
             end: end
             target: $ jsEvent.target
+            document: @options.document
+            openerEvent: jsEvent.originalEvent
 
 
     onPopoverClose: ->
@@ -328,4 +331,6 @@ module.exports = class CalendarView extends BaseView
         @showPopover
             type: model.fcEventType
             model: model
-            target: $(jsEvent.currentTarget)
+            target: $ jsEvent.currentTarget
+            document: @options.document,
+            openerEvent: jsEvent.originalEvent

--- a/client/app/views/event_popover.coffee
+++ b/client/app/views/event_popover.coffee
@@ -27,7 +27,7 @@ module.exports = class EventPopOver extends PopoverView
     # Events delegation. Generic popover controls are handled here.
     events:
         'keyup':                'onKeyUp'
-        'click .close':         'selfclose'
+        'click .close':         'close'
 
         # Used in all the screens to come back to the main screen.
         'click div.popover-back': -> @switchToScreen(@mainScreen)
@@ -68,51 +68,38 @@ module.exports = class EventPopOver extends PopoverView
 
     onKeyUp: (event) ->
         if event.keyCode is 27 # ESC
-            @selfclose()
-
-    displayConfirmIfNeeded: (checkoutChanges, callbackIfYes) ->
-        needConfirm = checkoutChanges and @modelHasChanged
-        dontConfirm = localStorage.dontConfirmCalendarPopover and
-                      localStorage.dontConfirmCalendarPopover isnt "false"
-        if needConfirm and not dontConfirm
-            @previousScreen = @screenElement.attr 'data-screen'
-            @callbackIfYes = callbackIfYes
-            @switchToScreen 'confirm'
-
-        else
-            callbackIfYes()
+            @close()
 
 
-    selfclose: (checkoutChanges = true) ->
-        @displayConfirmIfNeeded checkoutChanges, =>
-            # Revert if not just saved with addButton.
-            if @model.isNew()
-                super()
-            else
-                # Flag to checkout or not the un-persisted changes.
-                # Useful when the event is actually deleted.
-                if checkoutChanges
-                    @model.fetch complete: => super(checkoutChanges)
-                else
-                    super(checkoutChanges)
-
-        # Popover is closed so the extended status must be reset.
-        window.popoverExtended = false
+    confirmClose: (confirmCallback, cancelCallback) =>
+        @switchToScreen 'confirm',
+            confirmCallback: confirmCallback
+            cancelCallback: cancelCallback
 
 
-    close: (checkoutChanges = true) ->
-        # we don't reuse @selfclose because both are doing mostly the same thing
-        # but are a little bit different (see parent class).
-        # Revert if not just saved with addButton.
-        if @model.isNew()
-            super()
-        else
-            # Flag to checkout or not the un-persisted changes. Useful when the
-            # event is actually deleted.
-            if checkoutChanges
-                @model.fetch complete: super
-            else
-                super()
+    close: (callback) ->
+        if @closing
+            return
 
-        # Popover is closed so the extended status must be reset.
-        window.popoverExtended = false
+        @closing = true
+
+        formModelDiffers = not _.isEqual @context.formModel.attributes,
+                                    @model.attributes
+        userIgnoresConfirm = localStorage.dontConfirmCalendarPopover and
+                             localStorage.dontConfirmCalendarPopover is 'true'
+
+        needConfirm = formModelDiffers and not userIgnoresConfirm
+
+        return super(callback) if not needConfirm
+
+        confirmHandler = =>
+            super(callback)
+
+        screen = @context.screen
+
+        cancelHandler = =>
+            @closing = false
+            @switchToScreen screen
+
+        @confirmClose confirmHandler, cancelHandler
+

--- a/client/app/views/event_popover.coffee
+++ b/client/app/views/event_popover.coffee
@@ -52,6 +52,14 @@ module.exports = class EventPopOver extends PopoverView
         @listenToOnce @context.formModel, 'change', (model, options) =>
             @modelHasChanged = true
 
+    afterRender: ->
+        super()
+        # Pretty headache here. The Calendar view from full calendar trigger
+        # another click event on the far bottom part of a day cell.
+        # So, two Mouse event are triggered sometimes, and so we have to ignore
+        # click event from the closest parent div having the class fc-row
+        # To remind, @target here is a calendar cell (td element).
+        @clickOutListener.exceptOn @target.closest('.fc-row').get(0)
 
     momentToString: (m) ->
         if m.hasTime?() is false then m.toISOString().slice(0, 10)

--- a/client/app/views/event_popover.coffee
+++ b/client/app/views/event_popover.coffee
@@ -59,7 +59,10 @@ module.exports = class EventPopOver extends PopoverView
         # So, two Mouse event are triggered sometimes, and so we have to ignore
         # click event from the closest parent div having the class fc-row
         # To remind, @target here is a calendar cell (td element).
-        @clickOutListener.exceptOn @target.closest('.fc-row').get(0)
+        try
+            @clickOutListener.exceptOn @target.closest('.fc-row').get(0)
+        catch error
+            console.warn error
 
     momentToString: (m) ->
         if m.hasTime?() is false then m.toISOString().slice(0, 10)

--- a/client/app/views/pending_event_sharings_button.coffee
+++ b/client/app/views/pending_event_sharings_button.coffee
@@ -16,11 +16,13 @@ module.exports = class PendingEventSharingsButtonView extends CollectionView
         'keyup': 'onKeyUp'
 
 
-    initialize: ->
+    initialize: (options)->
         super()
 
         @counterView = new CollectionCounterView
             collection: @collection
+
+        @options = options
 
 
     togglePopup: (display) ->
@@ -40,6 +42,7 @@ module.exports = class PendingEventSharingsButtonView extends CollectionView
         @popup = new PopupView
             el: @$ @collectionEl
             anchor: @$el
+            document: @options.document
 
 
     addItem: (model) ->

--- a/client/app/views/popover_screens/confirm.coffee
+++ b/client/app/views/popover_screens/confirm.coffee
@@ -9,12 +9,24 @@ module.exports = class ConfirmClosePopoverScreen extends PopoverScreenView
     templateContent: require 'views/templates/popover_screens/confirm'
 
     events:
-        'click .answer-no': -> @switchToScreen(@popover.previousScreen)
-        'click .answer-yes': 'onYes'
+        'click .answer-no': -> @onCancel()
+        'click .answer-yes': -> @onConfirm()
         'change .dontaskagain': 'onCheckboxChange'
 
-    onYes: ->
-        @popover.callbackIfYes()
+    initialize: (options) ->
+        super()
+
+        @confirmCallback = options.data?.confirmCallback or
+            throw new Error 'No confirm callback has been set.'
+
+        @cancelCallback = options.data?.cancelCallback or
+            throw new Error 'No cancel callback has been set.'
+
+    onConfirm: ->
+        @confirmCallback()
+
+    onCancel: ->
+        @cancelCallback()
 
     onCheckboxChange: ->
         dontaskagain = $('.dontaskagain').is(':checked')

--- a/client/app/views/popover_screens/confirm.coffee
+++ b/client/app/views/popover_screens/confirm.coffee
@@ -9,8 +9,9 @@ module.exports = class ConfirmClosePopoverScreen extends PopoverScreenView
     templateContent: require 'views/templates/popover_screens/confirm'
 
     events:
-        'click .answer-no': -> @onCancel()
-        'click .answer-yes': -> @onConfirm()
+        'click .popover-back': (event) -> @onCancel(event)
+        'click .answer-no': (event) -> @onCancel(event)
+        'click .answer-yes': (event) -> @onConfirm(event)
         'change .dontaskagain': 'onCheckboxChange'
 
     initialize: (options) ->
@@ -22,10 +23,14 @@ module.exports = class ConfirmClosePopoverScreen extends PopoverScreenView
         @cancelCallback = options.data?.cancelCallback or
             throw new Error 'No cancel callback has been set.'
 
-    onConfirm: ->
+    onConfirm: (event) ->
+        # Avoid triggering click out for another popover
+        event.stopPropagation()
         @confirmCallback()
 
-    onCancel: ->
+    onCancel: (event) ->
+        # Avoid triggering click out for another popover
+        event.stopPropagation()
         @cancelCallback()
 
     onCheckboxChange: ->

--- a/client/app/views/popover_screens/delete.coffee
+++ b/client/app/views/popover_screens/delete.coffee
@@ -34,4 +34,4 @@ module.exports = class DeletePopoverScreen extends PopoverScreenView
                 @$errors.show()
             success: =>
                 @$spinner.hide()
-                @popover.selfclose(false)
+                @popover.close()

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -311,9 +311,16 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
                 @spinner.hide()
 
 
+    # Revert formModel to model state, so the close method will not
+    # detect any change.
+    cancelChanges: ->
+        @context.formModel = @model.clone()
+
+
     # Hides popover.
     onCancelClicked: ->
-        @popover.selfclose(true)
+        @cancelChanges()
+        @popover.close()
 
 
     onAddClicked: ->
@@ -348,7 +355,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
                     alert 'server error occured'
                 complete: =>
                     @$addButton.html @getButtonText()
-                    @popover.selfclose(false)
+                    @popover.close()
 
             if calendar.isNew()
                 calendar.save calendar.attributes,

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -166,7 +166,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
                 @description.focus()
 
         # Apply the expanded status if it has been previously set.
-        if window.popoverExtended
+        if @context.popoverExtended
             @expandPopover()
 
         # If all the optional fields are shown by default (they all have a
@@ -451,7 +451,7 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
 
         # Mark the popover has extended so the information is not lost when
         # screen is left.
-        window.popoverExtended = not window.popoverExtended
+        @context.popoverExtended = not @context.popoverExtended?
 
 
     # Show the optional fields of the screen (the ones hidden by default).


### PR DESCRIPTION
action.

* Add a `AddClickOutListener` method in BaseView to handle click outside any
element. This method provides way to ignore given events or source DOM elements.
It used for:
    * Recently created Pending shared events button's popup
    * Event popover

* Clean the way an event popover is closed. The recent changes on
model/formModel allowed us to remove some code and simplify the whole closing
process

* Enhance the closing method by passing it a callback. This callback is called
only when the event popover has been properly terminated, i.e. when the user
has confirmed that he does not want to keep the change. This new feature is used
    * When a new popover pops up
    * When the calendar view is changed

* The popover closing detection into CalendarView no rely on event listening,
and not on a callback passed to the popover anymore.

* Also, this PR adds some improvement on fullcalendar selection managing.

All this points have been commited in different commits.