### PR TITLE
Do not change calendar name/color unless anything really changes

### DIFF
--- a/client/app/views/menu_item.coffee
+++ b/client/app/views/menu_item.coffee
@@ -129,11 +129,12 @@ module.exports = class MenuItemView extends BaseView
             @showLoading()
             app.calendars.rename calendarName, input.val(), (name) =>
                 @model.set 'name', name
-                @model.set 'color', ColorHash.getColor(name, 'color')
+                if @model.isNew()
+                    @model.set 'color', ColorHash.getColor(name, 'color')
+                    @model.save()
+
                 @hideLoading()
                 @hideInput input
-        else
-            @buildBadge ColorHash.getColor(input.val(), 'color')
 
 
     # Replace the calendar's name by an input to edit the name.


### PR DESCRIPTION
* Do not change the calendar color when typing
* Only generate calendar color for new calendars (keep the current one when the calendar is renamed)

There is no need to use a proxy form model as in the envent popover, because the model has to be saved when every single change is made (changes are not performed via the same forms).