### PR TITLE
Enhance guest addition for share

### DIFF
--- a/client/app/collections/contacts.coffee
+++ b/client/app/collections/contacts.coffee
@@ -17,6 +17,13 @@ module.exports = class ContactCollection extends Backbone.Collection
                     display: "#{contact.get 'name'} &lt;#{email.value}&gt;"
                     toString: -> "#{email.value};#{contact.id}"
 
+            contact.get('cozy').forEach (cozy) ->
+                items.push
+                    id         : contact.id
+                    hasPicture : contact.get 'hasPicture'
+                    display    : "#{contact.get 'name'} &lt;#{cozy.value}&gt;"
+                    toString   : -> "#{cozy.value};#{contact.id}"
+
         return items
 
 

--- a/client/app/models/contact.coffee
+++ b/client/app/models/contact.coffee
@@ -3,6 +3,6 @@ module.exports = class Contact extends Backbone.Model
     urlRoot: 'contacts'
 
     match: (filter) ->
-        filter.test(@get('name')) or
+        filter.test(@get('name')) or filter.test(@get('cozy')) or
         @get('emails').some (dp) ->
             filter.test dp.get('value')

--- a/client/app/models/event.coffee
+++ b/client/app/models/event.coffee
@@ -197,7 +197,7 @@ module.exports = class Event extends ScheduleItem
             return @get 'attendees'
 
         @set 'attendees', @get('attendees').map (attendee) ->
-            return attendee if not attendee.shareWithCozy
+            return attendee if not attendee.share
 
             target = sharing.get('targets').find (target) ->
                 return target.recipientUrl == attendee.cozy

--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -326,7 +326,7 @@ module.exports = class ScheduleItem extends Backbone.Model
         # else: look state of each guest.
         attendees = @get('attendees') or []
         guestsToInform = attendees.filter (guest) =>
-            if guest.shareWithCozy
+            if guest.share
                 return false
 
             if method is 'create'

--- a/client/app/views/popover_screens/guests.coffee
+++ b/client/app/views/popover_screens/guests.coffee
@@ -49,8 +49,16 @@ module.exports = class GuestPopoverScreen extends EventPopoverScreenView
         # Create a list item for each alert.
         if attendees
             for guest, index in attendees
-                options = _.extend guest, {index}
-                row = @templateGuestRow _.extend guest, readOnly: @context.readOnly
+                options = _.extend guest,
+                    index       : index
+                    hideShare   : (not guest.cozy?)
+                    activeShare : guest.cozy? and guest.share
+                    hideEmail   : (not guest.email?)
+                    activeEmail : guest.email? and (not guest.share)
+
+                row = @templateGuestRow _.extend guest,
+                    readOnly: @context.readOnly
+
                 $guestElement.append row
 
         if not @context.readOnly

--- a/client/app/views/popover_screens/guests.coffee
+++ b/client/app/views/popover_screens/guests.coffee
@@ -156,9 +156,9 @@ module.exports = class GuestPopoverScreen extends EventPopoverScreenView
         guests.splice index, 1
 
         if share
-            guestBis = _.findWhere(guests, cozy: guest.cozy)
+            guestBis = _.findWhere(guests, {cozy: guest.cozy, share: share})
         else
-            guestBis = _.findWhere(guests, email: guest.email)
+            guestBis = _.findWhere(guests, {email: guest.email, share: share})
 
         # If the switch is email -> share then the parameter `share` is true
         # hence the label is the guest's cozy; if the switch is share -> email
@@ -167,8 +167,7 @@ module.exports = class GuestPopoverScreen extends EventPopoverScreenView
         guest.label = if share then guest.cozy else guest.email
 
         # If there is no duplicate the guest is added back to its original spot.
-        if (not guestBis?) or (share and (not guestBis.share)) or
-        ((not share) and guestBis.share)
+        if (not guestBis?)
             guests.splice index, 0, guest
 
         @formModel.set 'attendees', guests

--- a/client/app/views/styles/_popover.styl
+++ b/client/app/views/styles/_popover.styl
@@ -446,6 +446,7 @@ ul.guests
 
         & > *
             display table-cell
+            max-width 11.5em
             padding .5em
 
             &:last-child
@@ -466,14 +467,24 @@ ul.guests
             color grey-04
             padding .5em
 
-            &:hover
+            &:hover,
+            &.active
                 color darkblue
+
+            &.aria-hidden
+                visibility hidden
 
     .guest-label
         font-size 1.1em
         line-height 1.5em
         text-overflow ellipsis
         overflow hidden
+
+        &:hover
+            text-overflow clip
+            white-space normal
+            word-break break-all
+
 
 // Alerts screen
 ul.alerts

--- a/client/app/views/styles/_popover.styl
+++ b/client/app/views/styles/_popover.styl
@@ -471,7 +471,7 @@ ul.guests
             &.active
                 color darkblue
 
-            &.aria-hidden
+            &[aria-hidden]
                 visibility hidden
 
     .guest-label

--- a/client/app/views/templates/popover_screens/guest_row.jade
+++ b/client/app/views/templates/popover_screens/guest_row.jade
@@ -17,27 +17,6 @@ li.guest-top(data-index=index)
             role="button"
         )
 
-        - var hideShare    = true
-        - var hideEmail    = true
-        - var activeShare  = false
-        - var activeEmail  = false
-
-        // If a cozy instance is linked to a contact.
-        if cozy
-            - hideShare = false
-
-            // The invitation is shared.
-            if shareWithCozy
-                - activeShare  = true
-
-        // If the contact also has an email.
-        if email
-            - hideEmail = false
-
-            // The invitation is not shared, hence sent by email.
-            if !shareWithCozy
-                - activeEmail  = true
-
         button.guest-share-with-email.fa.fa-envelope-o(
             title=t('screen guest share with email tooltip')
             role='button'

--- a/client/app/views/templates/popover_screens/guest_row.jade
+++ b/client/app/views/templates/popover_screens/guest_row.jade
@@ -17,44 +17,40 @@ li.guest-top(data-index=index)
             role="button"
         )
 
-        - var displayShare = false
-        - var displayEmail = false
-        - var disableShare = false
-        - var disableEmail = false
+        - var hideShare    = true
+        - var hideEmail    = true
         - var activeShare  = false
         - var activeEmail  = false
 
         // If a cozy instance is linked to a contact.
         if cozy
-            - displayShare = true
+            - hideShare = false
 
             // The invitation is shared.
             if shareWithCozy
-                - disableShare = true
                 - activeShare  = true
 
         // If the contact also has an email.
         if email
-            - displayEmail = true
+            - hideEmail = false
 
             // The invitation is not shared, hence sent by email.
             if !shareWithCozy
-                - disableEmail = true
                 - activeEmail  = true
 
         button.guest-share-with-email.fa.fa-envelope-o(
             title=t('screen guest share with email tooltip')
             role='button'
             class=activeEmail ? 'active' : ''
-            disabled=disableEmail ? 'disabled' : false
-            class=displayEmail ? '' : 'aria-hidden'
+            disabled=activeEmail ? 'disabled' : false
+            aria-hidden=hideEmail
         )
 
         button.guest-share-with-cozy.fa.fa-cloud(
             title=t('screen guest share with cozy tooltip')
             role="button"
             class=activeShare ? 'active' : ''
-            disabled=disableShare ? 'disabled' : false
-            class=displayShare ? '' : 'aria-hidden'
+            disabled=activeShare ? 'disabled' : false
+            aria-hidden=hideShare
         )
 

--- a/client/app/views/templates/popover_screens/guest_row.jade
+++ b/client/app/views/templates/popover_screens/guest_row.jade
@@ -12,14 +12,49 @@ li.guest-top(data-index=index)
     .guest-label= label
 
     if !readOnly
-        span.button-wrapper
-            button.guest-delete.fa.fa-trash-o(title=t('screen guest remove tooltip'), role="button")
+        button.guest-delete.fa.fa-trash-o(
+            title=t('screen guest remove tooltip')
+            role="button"
+        )
 
-        // If a cozy instance is linked to a contact
+        - var displayShare = false
+        - var displayEmail = false
+        - var disableShare = false
+        - var disableEmail = false
+        - var activeShare  = false
+        - var activeEmail  = false
+
+        // If a cozy instance is linked to a contact.
         if cozy
+            - displayShare = true
+
+            // The invitation is shared.
             if shareWithCozy
-                span.button-wrapper
-                    button.guest-share-with-email.fa.fa-envelope-o(title=t('screen guest share with email tooltip'), role="button")
-            else
-                span.button-wrapper
-                    button.guest-share-with-cozy.fa.fa-cloud(title=t('screen guest share with cozy tooltip'), role="button")
+                - disableShare = true
+                - activeShare  = true
+
+        // If the contact also has an email.
+        if email
+            - displayEmail = true
+
+            // The invitation is not shared, hence sent by email.
+            if !shareWithCozy
+                - disableEmail = true
+                - activeEmail  = true
+
+        button.guest-share-with-email.fa.fa-envelope-o(
+            title=t('screen guest share with email tooltip')
+            role='button'
+            class=activeEmail ? 'active' : ''
+            disabled=disableEmail ? 'disabled' : false
+            class=displayEmail ? '' : 'aria-hidden'
+        )
+
+        button.guest-share-with-cozy.fa.fa-cloud(
+            title=t('screen guest share with cozy tooltip')
+            role="button"
+            class=activeShare ? 'active' : ''
+            disabled=disableShare ? 'disabled' : false
+            class=displayShare ? '' : 'aria-hidden'
+        )
+

--- a/server/mails/mail_handler.coffee
+++ b/server/mails/mail_handler.coffee
@@ -33,7 +33,7 @@ module.exports.sendInvitations = (event, dateChanged, callback) ->
         async.forEach guests, (guest, done) ->
 
             # only process relevant guests, quits otherwise
-            shouldSend = not guest.shareWithCozy and \
+            shouldSend = not guest.share and \
                 (guest.status is 'INVITATION-NOT-SENT' or \
                 (guest.status is 'ACCEPTED' and dateChanged))
             return done() unless shouldSend

--- a/server/models/contact.coffee
+++ b/server/models/contact.coffee
@@ -23,9 +23,9 @@ Contact::asNameAndEmails = ->
     emails = @datapoints?.filter (dp) -> dp.name is 'email'
 
     # XXX What if several Cozy instances are linked to one user?
-    cozy = dp.value for dp in @datapoints when (dp.name is 'other' and
-        dp.type is 'COZY') or (dp.name is 'url' and
-        dp.mediatype?.search 'cozy' isnt -1)
+    cozy = @datapoints?.filter (dp) -> ((dp.name is 'other') and
+        (dp.type.toLowerCase() is 'cozy')) or ((dp.name is 'url') and
+        (dp.mediatype?.search 'cozy' isnt -1))
 
     return simple =
         id         : @id

--- a/server/share/share_handler.coffee
+++ b/server/share/share_handler.coffee
@@ -22,7 +22,7 @@ module.exports.sendShareInvitations = (event, callback) ->
 
     # only process relevant guests
     guests.forEach (guest) ->
-        if guest.status is 'INVITATION-NOT-SENT' and guest.shareWithCozy
+        if guest.status is 'INVITATION-NOT-SENT' and guest.share
             data.targets.push recipientUrl: guest.cozy
             guest.status = "NEEDS-ACTION"
             needSaving   = true


### PR DESCRIPTION
This PR introduces the following changes:
* the search in the guest popover now also proposes Cozy url based on
what is present in the contact application;
* the calendar application can now handle a contact for whom several
Cozy instances are linked;
* if a guest has a Cozy url and an email in his contact information then
the user can decide if she wants to share the invitation or send it by
mail. It is possible to switch between those two possibilities thanks to
two new buttons. The currently selected option has its button
highlighted in blue;
* if it is not possible to switch from email to share, or from share to
email the button corresponding to the unavailable choice is hidden;
* a Cozy url can be typed directly in the search field. If no "@" is
found it is considered as the url of a Cozy. If a "@" is found it is
interpreted as an email address;
* if an email address or a Cozy url is too long to be displayed inside
the popover then the overflowing text is replaced by three dots and is
only displayed on two lines when hovering.