### PR TITLE
Improve UI for pending shared events notifications.

### DIFF
--- a/client/app/lib/base_view.coffee
+++ b/client/app/lib/base_view.coffee
@@ -102,3 +102,27 @@ module.exports = class BaseView extends Backbone.View
 
             listenedElements.forEach (element) ->
                 element.removeEventListener 'click', insideElementClickHandler
+
+
+    disable: ->
+        @$el.attr 'aria-disabled', true
+
+
+    enable: ($disabler)->
+        @$el.removeAttr 'aria-disabled'
+
+
+    setInvalid: ->
+        @$el.attr 'aria-invalid', true
+
+
+    setValid: ->
+        @$el.removeAttr 'aria-invalid'
+
+
+    setBusy: ->
+        @$el.attr 'aria-busy', true
+
+
+    setNotBusy: ->
+        @$el.removeAttr 'aria-busy'

--- a/client/app/views/pending_event_sharings_button_item.coffee
+++ b/client/app/views/pending_event_sharings_button_item.coffee
@@ -12,16 +12,35 @@ module.exports = class PendingEventSharingsButtonItemView extends BaseView
     initialize: ->
         @listenTo @model, 'accepted refused', @destroy
 
+
     onAccept: ->
+        @disable()
+        @setBusy()
         @model.accept (err) =>
             if err
                 @onAnswerError err
+            else
+                @onAnswerSuccess()
 
 
     onDecline: ->
+        @disable()
+        @setBusy()
         @model.refuse (err) =>
             if err
                 @onAnswerError err
+            else
+                @onAnswerSuccess()
+
+
+    onAnswerSuccess: ->
+        @setValid()
+        @remove()
+
 
     onAnswerError: (err) ->
-        console.error err
+        @$errors = @$errors ?= @$ '.errors'
+        @$errors.html t 'An error occurred. Please try again later.'
+        @setNotBusy()
+        @setInvalid()
+        @enable()

--- a/client/app/views/styles/_pending_event_sharings_button.styl
+++ b/client/app/views/styles/_pending_event_sharings_button.styl
@@ -9,6 +9,7 @@
     border-radius 1em
 
 .event-sharings-button-item
+    position relative
     line-height 1.5em
     margin-top 1em
     padding-bottom 1em
@@ -41,4 +42,38 @@
             &:active
                 color darkblue
                 text-decoration none
+
+    // Alternate states
+    .disabler,
+    .spinner,
+    .errors
+        display none
+
+    .disabler
+        background-color rgba(255,255,255,0.75)
+
+    &[aria-disabled],
+    &[aria-busy]
+        position relative
+
+    &[aria-disabled] .disabler,
+    &[aria-busy] .spinner
+        display block
+        position absolute
+        top 0
+        bottom 0
+        left 0
+        right 0
+
+    &[aria-busy] .spinner
+        display flex
+        align-items center
+        justify-content center
+
+        img
+            height 2em
+
+    &[aria-invalid] .errors
+        display block
+        color red
 

--- a/client/app/views/templates/pending_event_sharings_button_item.jade
+++ b/client/app/views/templates/pending_event_sharings_button_item.jade
@@ -1,6 +1,10 @@
 .sharer=model.sharerName || model.sharerUrl
 .desc=model.desc
+.errors
 .actions
     a.accept=t('Accept')
     span.separator=' • ' 
     a.decline=t('Decline')
+.disabler
+.spinner
+    img(src="img/spinner.svg")


### PR DESCRIPTION
Use three states :
* disabled
* busy
* invalid

Each one apply corresponding aria state to elment, the whole UI is done via CSS.
Those three states are set in Base View, so they can now be used by every view
in the app.