### PR TITLE
Check for error in sharing after an event is saved

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -11,7 +11,7 @@ module.exports =
             # Handler for asynchronous errors
             @onEventSharingError = (error) ->
                 # TODO find a better way to format a string like this
-                alert [ t('Event sharing failed for event'),
+                alert [ t('event sharing failed for event'),
                         error.event.get('description'),
                         '(' + t(error.message) + ')' ].join ' '
 
@@ -20,10 +20,10 @@ module.exports =
             # error = event.error
             errorHandlerName = 'on' + error.name
 
-            if @[errorHandlerName] and typeof @[errorHandlerName] == 'function'
+            if @[errorHandlerName] and typeof @[errorHandlerName] is 'function'
                 return @[errorHandlerName] error
             else if existingDefaultHandler and
-                        typeof existingDefaultHandler == 'function'
+                        typeof existingDefaultHandler is 'function'
                 return existingDefaultHandler msg, url, line, col, error
             else
                 throw error

--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -2,7 +2,37 @@ module.exports =
 
     listenTo: Backbone.Model.prototype.listenTo
 
-    initialize: ->
+
+    # Initialize a custom error handler for the global app
+    initializeErrorHandler: (window) ->
+        existingDefaultHandler = window.onerror
+
+        applicationErrorHandler = (msg, url, line, col, error) ->
+            # Handler for asynchronous errors
+            @onEventSharingError = (error) ->
+                # TODO find a better way to format a string like this
+                alert [ t('Event sharing failed for event'),
+                        error.event.get('description'),
+                        '(' + t(error.message) + ')' ].join ' '
+
+                return true
+
+            # error = event.error
+            errorHandlerName = 'on' + error.name
+
+            if @[errorHandlerName] and typeof @[errorHandlerName] == 'function'
+                return @[errorHandlerName] error
+            else if existingDefaultHandler and
+                        typeof existingDefaultHandler == 'function'
+                return existingDefaultHandler msg, url, line, col, error
+            else
+                throw error
+
+        window.onerror = applicationErrorHandler
+
+
+    initialize: (window) ->
+        @initializeErrorHandler(window)
 
         window.app = @
 

--- a/client/app/initialize.coffee
+++ b/client/app/initialize.coffee
@@ -78,7 +78,7 @@ $ ->
                 console.log "Spinner class not available."
                 null
 
-        app.initialize()
+        app.initialize(window)
 
     catch e
         console.error e, e?.stack

--- a/client/app/models/event.coffee
+++ b/client/app/models/event.coffee
@@ -104,9 +104,9 @@ module.exports = class Event extends ScheduleItem
     # A shared event has at least one attendees with a cozy invitation
     isShared: ->
         attendees = @get 'attendees'
-        hasCozyAttendees = attendees?.find (attendee) ->
+        cozyAttendees = attendees?.find (attendee) ->
             return attendee.shareWithCozy
-        return hasCozyAttendees
+        return cozyAttendees?
 
 
     # Try to get a shareID (called typically just after saving),

--- a/client/app/models/event.coffee
+++ b/client/app/models/event.coffee
@@ -101,6 +101,81 @@ module.exports = class Event extends ScheduleItem
     getDefaultColor: -> '#008AF6'
 
 
+    # A shared event has at least one attendees with a cozy invitation
+    isShared: ->
+        attendees = @get 'attendees'
+        hasCozyAttendees = attendees?.find (attendee) ->
+            return attendee.shareWithCozy
+        return hasCozyAttendees
+
+
+    # Try to get a shareID (called typically just after saving),
+    tryGetShareID: (numtries, delay, callback) ->
+
+        @fetch
+            success: (model, response) =>
+                shareID = model.get 'shareID'
+                if shareID
+                    callback null, shareID
+                    return
+
+                triesLeft = --numtries;
+
+                if numtries
+                    setTimeout =>
+                        @tryGetShareID triesLeft, delay, callback
+                    , delay
+                else
+                    callback 'Could not retrieve shareID, maximum \
+                        number of tries exceeded',
+                        null
+            error: (model, response) ->
+                callback(response.error or response, null)
+
+
+    # Fetch the sharing object to handle any error
+    onShareIDChange: ->
+        @fetchSharing (err, sharing) =>
+            if err
+                throw
+                    name: 'EventSharingError',
+                    event: @
+                    message: 'cannot retrieve sharing : ' + err
+            else
+                sharing.getFailedTargets().forEach (target) =>
+                    throw
+                        name: 'EventSharingError',
+                        event: @
+                        message: [ target.recipientUrl, ':',
+                                    target.error ].join ' '
+
+
+    # Override the native save mehod to bypass the success callback with
+    # a custom one dealing with event sharing case.
+    # The idea is to only call the success callback when the shareID
+    # has been actually fetched.
+    save: (attributes, options) ->
+        successCallback = options?.success
+        options.success = (model, response, options) =>
+            # Call the original success handler, before dealing with
+            # sharing aspect
+            successCallback model, response, options
+
+            # And then deal with the sharing
+            # The goal is to detect any error occurring asynchronously
+            if @isShared() and not @hasSharing()
+               @tryGetShareID 5, 2000, ( err, shareID ) =>
+                    if err
+                        throw
+                            name: 'EventSharingError'
+                            event: @
+                            message: err
+                    else
+                        @onShareIDChange()
+
+        super attributes, options
+
+
     hasSharing: ->
         return @get('shareID')?
 

--- a/client/app/models/event.coffee
+++ b/client/app/models/event.coffee
@@ -140,14 +140,13 @@ module.exports = class Event extends ScheduleItem
                 throw
                     name: 'EventSharingError',
                     event: @
-                    message: 'cannot retrieve sharing : ' + err
+                    message: err
             else
                 sharing.getFailedTargets().forEach (target) =>
                     throw
                         name: 'EventSharingError',
                         event: @
-                        message: [ target.recipientUrl, ':',
-                                    target.error ].join ' '
+                        target: target
 
 
     # Override the native save mehod to bypass the success callback with

--- a/client/app/models/event.coffee
+++ b/client/app/models/event.coffee
@@ -109,7 +109,7 @@ module.exports = class Event extends ScheduleItem
         return cozyAttendees?
 
 
-    # Try to get a shareID (called typically just after saving),
+    # Try to get a shareID (called typically just after saving).
     tryGetShareID: (numtries, delay, callback) ->
 
         @fetch

--- a/client/app/models/sharing.coffee
+++ b/client/app/models/sharing.coffee
@@ -22,3 +22,9 @@ module.exports = class Sharing extends Backbone.Model
             else
                 callback null, response
                 @trigger 'refused', @
+
+
+    # Returns an array of sharing's targets having errors
+    getFailedTargets: ->
+        return @get('targets')?.filter (target) ->
+            return target.error?

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -346,10 +346,6 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
                 wait: true
                 success: (model, response) =>
                     app.events.add model, sort: false
-
-                    isShared = model.get('shareID')?
-                    @onSharedEventSync(model) if isShared
-
                 error: ->
                     # TODO better error handling
                     alert 'server error occured'
@@ -368,14 +364,6 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
                         alert 'server error occured'
             else
                 saveEvent()
-
-    # Fetch the sharing object to handle any error
-    onSharedEventSync: (event) ->
-        event.fetchSharing (err, sharing) =>
-            err = err ?= sharing.error
-            if err
-                console.error err
-                alert 'Sharing with Cozy users failed'
 
 
     handleError: (error) ->


### PR DESCRIPTION
As the sharing creation occurs after an event save in the data sytem, we can't
if the sharing succeed or not right after the event creation.

Instead of relying on realtime service (which can fail, be down, etc), we try
to get the shareID every interval of a given time. When the shareID is finally
fetched, we get the sharing to check if its targets contain any error. If so, we
throw them.

If the shareID cannot be fetched, an error is also thrown.