### PR TITLE
Prevent automatic share

### DIFF
--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -309,12 +309,10 @@ module.exports = class ScheduleItem extends Backbone.Model
         # attributes in the model.
         frozenModel = model.clone()
 
-        @confirmSendEmails method, (sendMails) =>
-            @hasShare method, (share) ->
-                # overrides the url to append the sendmails parameter
-                options.url  = "#{model.url()}?sendMails=#{sendMails}"
-                options.url += "&share=#{share}"
-                return super method, frozenModel, options
+        @confirmSendEmails method, (sendMails) ->
+            # overrides the url to append the sendmails parameter
+            options.url  = "#{model.url()}?sendMails=#{sendMails}"
+            return super method, frozenModel, options
 
 
     confirmSendEmails: (method, callback) ->
@@ -323,7 +321,7 @@ module.exports = class ScheduleItem extends Backbone.Model
 
         # Kind of changes which doesn't need mails.
         if method in ['update', 'patch'] and
-        not ( @startDateChanged or @attendeesChanged)
+        not (@startDateChanged or @attendeesChanged)
             return callback false
 
         # else: look state of each guest.
@@ -355,29 +353,5 @@ module.exports = class ScheduleItem extends Backbone.Model
                 t('yes'), t('no'), callback
 
         @startDateChanged = false
-
-
-    hasShare: (method, callback) =>
-        # No share on files import or deletion.
-        if (@get 'import') or (method is 'delete')
-            return callback false
-
-        if (method in ['update', 'patch']) and (not @attendeesChanged)
-            return callback false
-
         @attendeesChanged = false
-
-        attendees = @get('attendees') or []
-        i = 0
-        guest = attendees[i]
-
-        while guest
-            if guest.shareWithCozy and ((method is 'create') or
-            (guest.status is 'INVITATION-NOT-SENT'))
-                return callback true
-
-            i++
-            guest = attendees[i]
-
-        return callback false
 

--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -321,7 +321,7 @@ module.exports = class ScheduleItem extends Backbone.Model
 
         # Kind of changes which doesn't need mails.
         if method in ['update', 'patch'] and
-        not (@startDateChanged or @attendeesChanged)
+                not (@startDateChanged or @attendeesChanged)
             return callback false
 
         # else: look state of each guest.

--- a/server/controllers/events.coffee
+++ b/server/controllers/events.coffee
@@ -52,7 +52,7 @@ module.exports.create = (req, res) ->
             else
                 ShareHandler.sendShareInvitations event, (err, updatedEvent) ->
                     # If the event has guests that are notified by email and for
-                    # whom the owner confirmed s.he wanted to send emails, we
+                    # whom the owner confirmed she wanted to send emails, we
                     # send the emails.
                     if req.query.sendMails is 'true'
                         MailHandler.sendInvitations (updatedEvent or event),

--- a/server/controllers/events.coffee
+++ b/server/controllers/events.coffee
@@ -50,20 +50,29 @@ module.exports.create = (req, res) ->
             if data.import
                 res.status(201).send event
             else
-                # We first share the events, if the event is shared (this
-                # condition is checked within `sendShareInvitations`)
-                ShareHandler.sendShareInvitations event, (err, updatedEvent) ->
-
-                    # If the event has guests that are notified by email and for
-                    # whom the owner confirmed she wanted to send emails, we
-                    # send the emails
-                    if req.query.sendMails is 'true'
-                        MailHandler.sendInvitations (updatedEvent or event),
-                        false, (err, updatedEvent) ->
+                # If at least one guest has the event shared
+                if req.query.share is 'true'
+                    ShareHandler.sendShareInvitations event,
+                    (err, updatedEvent) ->
+                        # If the event has guests that are notified by email and
+                        # for whom the owner confirmed she wanted to send
+                        # emails, we send the emails
+                        if req.query.sendMails is 'true'
+                            MailHandler.sendInvitations (updatedEvent or event),
+                            false, (err, updatedEvent) ->
+                                res.status(201).send (updatedEvent or event)
+                        # Otherwise we just update the event
+                        else
                             res.status(201).send (updatedEvent or event)
-                    # Otherwise we just update the event
+
+                # No guest has the event shared
+                else
+                    if req.query.sendMails is 'true'
+                        MailHandler.sendInvitations event, false,
+                        (err, updatedEvent) ->
+                            res.status(201).send (updatedEvent or event)
                     else
-                        res.status(201).send (updatedEvent or event)
+                        res.status(201).send event
 
 
 # Expect a list of events as body and create an event in database for each
@@ -101,15 +110,26 @@ module.exports.update = (req, res) ->
         if err?
             res.status(500).send error: "Server error while saving event"
         else
-            ShareHandler.sendShareInvitations event, (err, updatedEvent) ->
+            if req.query.share is 'true'
+                ShareHandler.sendShareInvitations event, (err, updatedEvent) ->
+                    if req.query.sendMails is 'true'
+                        dateChanged = data.start isnt start
+
+                        MailHandler.sendInvitations (updatedEvent or event),
+                        dateChanged, (err, updatedEvent) ->
+                            res.status(201).send (updatedEvent or event)
+                    else
+                        res.status(201).send event
+
+            else
                 if req.query.sendMails is 'true'
                     dateChanged = data.start isnt start
 
-                    MailHandler.sendInvitations (updatedEvent or event),
-                    dateChanged, (err, updatedEvent) ->
-                        res.send (updatedEvent or event)
+                    MailHandler.sendInvitations event, dateChanged,
+                    (err, updatedEvent) ->
+                        res.status(201).send (updatedEvent or event)
                 else
-                    res.send event
+                    res.status(201).send event
 
 
 module.exports.delete = (req, res) ->

--- a/server/controllers/events.coffee
+++ b/server/controllers/events.coffee
@@ -50,29 +50,17 @@ module.exports.create = (req, res) ->
             if data.import
                 res.status(201).send event
             else
-                # If at least one guest has the event shared
-                if req.query.share is 'true'
-                    ShareHandler.sendShareInvitations event,
-                    (err, updatedEvent) ->
-                        # If the event has guests that are notified by email and
-                        # for whom the owner confirmed she wanted to send
-                        # emails, we send the emails
-                        if req.query.sendMails is 'true'
-                            MailHandler.sendInvitations (updatedEvent or event),
-                            false, (err, updatedEvent) ->
-                                res.status(201).send (updatedEvent or event)
-                        # Otherwise we just update the event
-                        else
-                            res.status(201).send (updatedEvent or event)
-
-                # No guest has the event shared
-                else
+                ShareHandler.sendShareInvitations event, (err, updatedEvent) ->
+                    # If the event has guests that are notified by email and for
+                    # whom the owner confirmed s.he wanted to send emails, we
+                    # send the emails.
                     if req.query.sendMails is 'true'
-                        MailHandler.sendInvitations event, false,
-                        (err, updatedEvent) ->
+                        MailHandler.sendInvitations (updatedEvent or event),
+                        false, (err, updatedEvent) ->
                             res.status(201).send (updatedEvent or event)
+                    # Otherwise we just update the event
                     else
-                        res.status(201).send event
+                        res.status(201).send (updatedEvent or event)
 
 
 # Expect a list of events as body and create an event in database for each
@@ -110,26 +98,15 @@ module.exports.update = (req, res) ->
         if err?
             res.status(500).send error: "Server error while saving event"
         else
-            if req.query.share is 'true'
-                ShareHandler.sendShareInvitations event, (err, updatedEvent) ->
-                    if req.query.sendMails is 'true'
-                        dateChanged = data.start isnt start
-
-                        MailHandler.sendInvitations (updatedEvent or event),
-                        dateChanged, (err, updatedEvent) ->
-                            res.status(201).send (updatedEvent or event)
-                    else
-                        res.status(201).send event
-
-            else
+            ShareHandler.sendShareInvitations event, (err, updatedEvent) ->
                 if req.query.sendMails is 'true'
                     dateChanged = data.start isnt start
 
-                    MailHandler.sendInvitations event, dateChanged,
-                    (err, updatedEvent) ->
+                    MailHandler.sendInvitations (updatedEvent or event),
+                    dateChanged, (err, updatedEvent) ->
                         res.status(201).send (updatedEvent or event)
                 else
-                    res.status(201).send event
+                    res.status(201).send (updatedEvent or event)
 
 
 module.exports.delete = (req, res) ->

--- a/server/share/share_handler.coffee
+++ b/server/share/share_handler.coffee
@@ -5,6 +5,15 @@ module.exports.sendShareInvitations = (event, callback) ->
     guests     = event.toJSON().attendees
     needSaving = false
 
+    # Before proceeding any further we check here that we have to share the
+    # event with at least one guest.
+    hasGuestToShare = guests.find (guest) ->
+        return (guest.share and (guest.status is 'INVITATION-NOT-SENT'))
+
+    # If we haven't found a single guest to share the event with, we stop here.
+    unless hasGuestToShare
+        return callback()
+
     # The format of the req.body to send must match:
     #
     # desc      : the sharing description
@@ -30,8 +39,9 @@ module.exports.sendShareInvitations = (event, callback) ->
     # Send the request to the datasystem
     cozydb.api.createSharing data, (err, body) ->
         if err?
-            callback err
+            return callback err
         else unless needSaving
-            callback()
+            return callback()
         else
             event.updateAttributes attendees: guests, callback
+


### PR DESCRIPTION
Based on PR #551 
---

Before this PR the behaviour was to always start the "share routine" on
the server side, even if an event is not shared.
With those changes the "share routine" resembles that of the mail: the
client side of the calendar application adds a parameter `share` to the
url to inform on whether or not the event is shared. The routine is then
launched only when needed.