### PR TITLE
Rename share

### DIFF
--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -327,7 +327,7 @@ module.exports = class ScheduleItem extends Backbone.Model
         # else: look state of each guest.
         attendees = @get('attendees') or []
         guestsToInform = attendees.filter (guest) =>
-            if guest.share
+            if guest.isSharedWithCozy
                 return false
 
             if method is 'create'

--- a/server/mails/mail_handler.coffee
+++ b/server/mails/mail_handler.coffee
@@ -33,7 +33,7 @@ module.exports.sendInvitations = (event, dateChanged, callback) ->
         async.forEach guests, (guest, done) ->
 
             # only process relevant guests, quits otherwise
-            shouldSend = not guest.share and \
+            shouldSend = not guest.isSharedWithCozy and \
                 (guest.status is 'INVITATION-NOT-SENT' or \
                 (guest.status is 'ACCEPTED' and dateChanged))
             return done() unless shouldSend

--- a/server/share/share_handler.coffee
+++ b/server/share/share_handler.coffee
@@ -8,7 +8,8 @@ module.exports.sendShareInvitations = (event, callback) ->
     # Before proceeding any further we check here that we have to share the
     # event with at least one guest.
     hasGuestToShare = guests.find (guest) ->
-        return (guest.share and (guest.status is 'INVITATION-NOT-SENT'))
+        return (guest.isSharedWithCozy and
+               (guest.status is 'INVITATION-NOT-SENT'))
 
     # If we haven't found a single guest to share the event with, we stop here.
     unless hasGuestToShare
@@ -31,7 +32,7 @@ module.exports.sendShareInvitations = (event, callback) ->
 
     # only process relevant guests
     guests.forEach (guest) ->
-        if guest.status is 'INVITATION-NOT-SENT' and guest.share
+        if (guest.status is 'INVITATION-NOT-SENT') and guest.isSharedWithCozy
             data.targets.push recipientUrl: guest.cozy
             guest.status = "NEEDS-ACTION"
             needSaving   = true
@@ -39,9 +40,9 @@ module.exports.sendShareInvitations = (event, callback) ->
     # Send the request to the datasystem
     cozydb.api.createSharing data, (err, body) ->
         if err?
-            return callback err
+            callback err
         else unless needSaving
-            return callback()
+            callback()
         else
             event.updateAttributes attendees: guests, callback
 


### PR DESCRIPTION
Based on PR #555 
---

After discussing with the team we decided to rename this parameter for
clarity. "share" was a little too generic compared to what we can do for
the moment.

I also slightly improved the function `removeIfDuplicate`.