### PR TITLE
Fix the guests layout in the event popover by using a <table> element.

### DIFF
--- a/client/app/views/styles/_popover.styl
+++ b/client/app/views/styles/_popover.styl
@@ -3,8 +3,10 @@
 // ----------------------------------------------------------------------------
 // TODO: rebuild all styles with relative units. Need to revamp a whole bunch
 //       of the app styles
+popover-width = 25em
+
 .popover
-    width: 25em
+    width: popover-width
     max-width: none
     padding: 0
     font-family: 'Source Sans Pro', sans-serif
@@ -425,12 +427,14 @@ select.select-big
         overflow hidden
         text-overflow ellipsis
 
-ul.guests
+// .fc table to override .fc table coming from nowhere
+.fc table.guests
     margin 0
     list-style-type none
 
-    display table
-    width 100%
+
+    width popover-width - 3em
+    margin 0 1.5em
 
     li
         padding 1em 1.5em
@@ -441,23 +445,16 @@ ul.guests
             border-bottom 1px solid grey-03
 
     .guest-top
-        display table-row
-        align-items center
+        td
+            vertical-align middle
+            border-width 0
 
-        & > *
-            display table-cell
-            max-width 11.5em
-            padding .5em
+        &.status,
+        &.action
+                text-align center
 
-            &:last-child
-                padding-right 1.5em
-
-            &:first-child
-                padding-left 1.5em
-
-        .status,
-        .button-wrapper
-            width 1em
+        &.status
+            width 1.5em
 
     .guest-top button
             height auto
@@ -479,11 +476,7 @@ ul.guests
         line-height 1.5em
         text-overflow ellipsis
         overflow hidden
-
-        &:hover
-            text-overflow clip
-            white-space normal
-            word-break break-all
+        width 60%
 
 
 // Alerts screen

--- a/client/app/views/templates/popover_screens/guest_row.jade
+++ b/client/app/views/templates/popover_screens/guest_row.jade
@@ -1,5 +1,5 @@
-li.guest-top(data-index=index)
-    span.status
+tr.guest-top(data-index=index)
+    td.status
         if status == 'ACCEPTED'
             i.fa.fa-check-circle-o.green(title=t('accepted'))
         else if status == 'DECLINED'
@@ -9,27 +9,31 @@ li.guest-top(data-index=index)
         else
             i.fa.fa-exclamation-circle.orange(title=t('mail not sent'))
 
-    .guest-label= label
+    td.guest-label(title=label)= label
 
-    if !readOnly
-        button.guest-delete.fa.fa-trash-o(
-            title=t('screen guest remove tooltip')
-            role="button"
-        )
+    if readOnly
+        td[colspan=3]
+    else
+        td.action
+            button.guest-delete.fa.fa-trash-o(
+                title=t('screen guest remove tooltip')
+                role="button"
+            )
+        td.action
+            button.guest-share-with-email.fa.fa-envelope-o(
+                title=t('screen guest share with email tooltip')
+                role='button'
+                class=activeEmail ? 'active' : ''
+                disabled=activeEmail ? 'disabled' : false
+                aria-hidden=hideEmail
+            )
+        td.action
+            button.guest-share-with-cozy.fa.fa-cloud(
+                title=t('screen guest share with cozy tooltip')
+                role="button"
+                class=activeShare ? 'active' : ''
+                disabled=activeShare ? 'disabled' : false
+                aria-hidden=hideShare
+            )
 
-        button.guest-share-with-email.fa.fa-envelope-o(
-            title=t('screen guest share with email tooltip')
-            role='button'
-            class=activeEmail ? 'active' : ''
-            disabled=activeEmail ? 'disabled' : false
-            aria-hidden=hideEmail
-        )
-
-        button.guest-share-with-cozy.fa.fa-cloud(
-            title=t('screen guest share with cozy tooltip')
-            role="button"
-            class=activeShare ? 'active' : ''
-            disabled=activeShare ? 'disabled' : false
-            aria-hidden=hideShare
-        )
 

--- a/client/app/views/templates/popover_screens/guests.jade
+++ b/client/app/views/templates/popover_screens/guests.jade
@@ -5,4 +5,4 @@
             input(type="text", name="guest-name", placeholder=t('screen guest input placeholder'))
             button.btn.add-new-guest=t('screen guest add button')
 
-    ul.guests
+    table.guests


### PR DESCRIPTION
As the JS logic behing this screen was based on data recuperation in DOM,
changing the elements broke the feature. So I also adapted the JS code to be now
DOM independant, so future changes in templates should not affect the behaviour
anymore.