### PR TITLE
Fix handling of click in confirm emails modal.

### DIFF
--- a/client/app/views/event_popover.coffee
+++ b/client/app/views/event_popover.coffee
@@ -49,6 +49,12 @@ module.exports = class EventPopOver extends PopoverView
         @listenTo @model, 'change:shareID', =>
             @context.formModel.set 'shareID', @model.get 'shareID'
 
+        # Listen to attendees, they could be change by a call to event.prepare
+        # before a deletion of an event. If so, we have to keep attendees equals
+        # to avoid a warning message after delete confirmation.
+        @listenTo @model, 'change:attendees', =>
+            @context.formModel.set 'attendees', @model.get 'attendees'
+
         @listenToOnce @context.formModel, 'change', (model, options) =>
             @modelHasChanged = true
 

--- a/client/app/views/popover_screens/delete.coffee
+++ b/client/app/views/popover_screens/delete.coffee
@@ -31,11 +31,16 @@ module.exports = class DeletePopoverScreen extends PopoverScreenView
 
         if guestsToInform.length
             guestsList = guestsToInform.map((guest) -> guest.label).join ', '
-            Modal.confirm t('modal send mails'),
+            modal = Modal.confirm t('modal send mails'),
                 "#{t 'send delete notifications'} #{guestsList}", \
                 t('yes'),
                 t('no'),
                 (result) -> callback null, result
+
+            @context.clickOutListener.exceptOn [
+                    modal.el,
+                    modal.getBackdrop() ]
+
         else
             callback null, false
 

--- a/client/app/views/popover_screens/delete.coffee
+++ b/client/app/views/popover_screens/delete.coffee
@@ -1,4 +1,5 @@
 PopoverScreenView = require 'lib/popover_screen_view'
+Modal = require 'lib/modal'
 
 module.exports = class DeletePopoverScreen extends PopoverScreenView
 
@@ -21,17 +22,37 @@ module.exports = class DeletePopoverScreen extends PopoverScreenView
         @$spinner.hide()
         @$errors.hide()
 
+    # Display a modal to confirm sending of emails to notify attendees
+    confirmEmailNotifications: (model, callback) ->
+        attendees = model.get('attendees') or []
+        guestsToInform = attendees.filter (guest) =>
+            return not guest.isSharedWithCozy and
+                guest.status in ['ACCEPTED', 'NEEDS-ACTION']
+
+        if guestsToInform.length
+            guestsList = guestsToInform.map((guest) -> guest.label).join ', '
+            Modal.confirm t('modal send mails'),
+                "#{t 'send delete notifications'} #{guestsList}", \
+                t('yes'),
+                t('no'),
+                (result) -> callback null, result
+        else
+            callback null, false
+
 
     onDelete: ->
         @$errors.hide()
         @$spinner.show()
         @$removeChoices.hide()
-        @model.destroy
-            wait: true
-            error: =>
-                @$removeChoices.show()
-                @$errors.html t('server error occured')
-                @$errors.show()
-            success: =>
-                @$spinner.hide()
-                @popover.close()
+
+        @confirmEmailNotifications @model, (err, sendEmailNotifications) =>
+            @model.destroy
+                wait: true
+                url: "#{@model.url()}?sendMails=#{sendEmailNotifications}"
+                error: =>
+                    @$removeChoices.show()
+                    @$errors.html t('server error occured')
+                    @$errors.show()
+                success: =>
+                    @$spinner.hide()
+                    @popover.close()

--- a/client/app/views/popover_screens/main.coffee
+++ b/client/app/views/popover_screens/main.coffee
@@ -390,11 +390,16 @@ module.exports = class MainPopoverScreen extends PopoverScreenView
 
         if guestsToInform.length
             guestsList = guestsToInform.map((guest) -> guest.label).join ', '
-            Modal.confirm t('modal send mails'),
+            modal = Modal.confirm t('modal send mails'),
                 "#{t 'send invitations question'} #{guestsList}", \
                 t('yes'),
                 t('no'),
                 (result) -> callback null, result
+
+            @context.clickOutListener.exceptOn [
+                    modal.el,
+                    modal.getBackdrop() ]
+
         else
             callback null, false
 


### PR DESCRIPTION
A click on the modal or its "backdrop" element was previously triggering a
"click outside" and a closing of the event popover.

The main problem was that the logic of this modal display was in model,
forbidding access to view properies like `clickOutListener`. So first I fixed
this design by bringing back the modal's logic into the event popover view. It
also simplified the code and removed a dirty hack to keep the model consistent.

Then I added a method to the Modal lib to be able to retrieve the backdrop
element, to then add it to the element list to ignore when they trigger a click
event.