### PR TITLE
Fix calendar without color

### DIFF
--- a/client/app/collections/calendars.coffee
+++ b/client/app/collections/calendars.coffee
@@ -1,13 +1,14 @@
 SocketListener = require '../lib/socket_listener'
 Tag = require 'models/tag'
+Calendar = require 'models/calendar'
 TagCollection = require 'collections/tags'
 request = require 'lib/request'
 
-stringify = (tag) -> tag.toString()
+stringify = (calendar) -> calendar.toString()
 
 module.exports = class CalendarCollection extends TagCollection
 
-    model: Tag
+    model: Calendar
 
 
     initialize: ->
@@ -82,9 +83,9 @@ module.exports = class CalendarCollection extends TagCollection
 
 
     toAutoCompleteSource: ->
-        return @map (tag) ->
+        return @map (calendar) ->
             return _.extend
-                label: tag.get 'name'
-                value: tag.get 'name'
-            , tag.attributes
+                label: calendar.get 'name'
+                value: calendar.get 'name'
+            , calendar.attributes
 

--- a/client/app/models/calendar.coffee
+++ b/client/app/models/calendar.coffee
@@ -9,20 +9,29 @@ module.exports = class Calendar extends Tag
         # color assigned. So we set it at initialization and will try
         # to save it as soon as a change is made on the calendar.
         color = @get 'color'
-        @hasColorDefined =
-            color and color.match /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+        @hasValidColorStoredInDB = @isColorValid color
 
-        if not @hasColorDefined
+        if not @hasValidColorStoredInDB
             # Temporary color until a save is made
             @set 'color', ColorHash.getColor @get 'name'
+
+
+    isColorValid: (color) ->
+        return color? and /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test color
 
 
     # Take proffit of a saving to save the color.
     save: (attributes, options) ->
         attributes = attributes ?= {}
-        if not @hasColorDefined and not attributes?.color?
+        if not @hasValidColorStoredInDB and not attributes?.color?
             attributes.color = @get 'color'
 
+        # Add intermediate success callback to set @hasValidColorStoredInDB.
+        options = options ?= {}
+        successCallback = options.success
+        options.success = (model, response, options) =>
+            @hasValidColorStoredInDB = @isColorValid response.color
+            if typeof successCallback is 'function'
+                successCallback model, response, options
+
         super attributes, options
-
-

--- a/client/app/models/calendar.coffee
+++ b/client/app/models/calendar.coffee
@@ -1,0 +1,28 @@
+Tag = require './tag'
+
+module.exports = class Calendar extends Tag
+
+    initialize: (options) ->
+        super options
+
+        # When created via Data System, a calendar should not have any
+        # color assigned. So we set it at initialization and will try
+        # to save it as soon as a change is made on the calendar.
+        color = @get 'color'
+        @hasColorDefined =
+            color and color.match /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/
+
+        if not @hasColorDefined
+            # Temporary color until a save is made
+            @set 'color', ColorHash.getColor @get 'name'
+
+
+    # Take proffit of a saving to save the color.
+    save: (attributes, options) ->
+        attributes = attributes ?= {}
+        if not @hasColorDefined and not attributes?.color?
+            attributes.color = @get 'color'
+
+        super attributes, options
+
+


### PR DESCRIPTION
As we are going to use a model object for calendar instead of refering it as a
Tag, this issue was the good opportunity to finally create a Calendar class.
At this time, it only inherit from Tag and ad an empty color detection.

It allows to avoid some be UI issues when a calendar color is not set.

This change implies some little updates in CalendarColleciton class.