### PR TITLE
Fix multiple days event displayed as "All day" in list view

### DIFF
--- a/client/app/models/realevent.coffee
+++ b/client/app/models/realevent.coffee
@@ -8,9 +8,9 @@ module.exports = class RealEvent extends Backbone.Model
 
         @event = options.event
         @start = options.start
-        @end = options.start
+        @end = options.end
         @counter = options.counter
-
+        @forceAllDay = options.isAllDay
 
         if @event.isRecurrent()
             @set 'id', @event.get('id') + @start.toISOString()
@@ -23,12 +23,13 @@ module.exports = class RealEvent extends Backbone.Model
             @start = @event.getStartDateObject()
             @end = @event.getEndDateObject()
 
+
     getCalendar: -> @event.getCalendar()
     getColor: -> @event.getColor()
     getDateHash: ->
         return @start?.format 'YYYYMMDD'
 
-    isAllDay: -> @event.isAllDay() or @event.isMultipleDays()
+    isAllDay: -> @event.isAllDay() or @forceAllDay
 
     getFormattedStartDate: (format) ->
         return @start?.format format

--- a/client/app/models/scheduleitem.coffee
+++ b/client/app/models/scheduleitem.coffee
@@ -250,8 +250,9 @@ module.exports = class ScheduleItem extends Backbone.Model
                 # Make up a date for the i-th day.
                 date = moment(startDate).add(i, 'days')
                 fakeEvent =
-                    start: date
-                    end: date
+                    start: if i is 0 then startDate else date.startOf 'day'
+                    end: if i is difference then endDate else date.endOf 'day'
+                    isAllDay: i not in [0, difference]
                     counter:
                         current: i + 1
                         total: difference + 1


### PR DESCRIPTION
Multiple-days events are now displayed with their starting and ending time respectively in the first and last day