### PR TITLE
Fix "legacy" issue with method `find`

### DIFF
--- a/server/share/share_handler.coffee
+++ b/server/share/share_handler.coffee
@@ -1,5 +1,29 @@
 cozydb    = require 'cozydb'
 
+# Polyfill to provide the function `find` if it is not already implemented
+# See : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/
+#                   Global_Objects/Array/find
+unless Array.prototype.find
+    Array.prototype.find = (predicate) ->
+        if this is null
+            throw new TypeError "Find call on null or undefined."
+
+        if (typeof predicate) isnt "function"
+            throw new TypeError "Predicate must be a function."
+
+        list    = Object this
+        length  = list.length >>> 0
+        thisArg = arguments[1]
+        i       = 0
+        value   = list[i]
+
+        while value
+            if predicate.call thisArg, value, i, list
+                return value
+            value = list[++i]
+
+        return undefined
+
 
 module.exports.sendShareInvitations = (event, callback) ->
     guests     = event.toJSON().attendees
@@ -45,4 +69,5 @@ module.exports.sendShareInvitations = (event, callback) ->
             callback()
         else
             event.updateAttributes attendees: guests, callback
+
 


### PR DESCRIPTION
On older version of node the method `find` for the array does not exist
which causes problems. With this commit the method is defined in all
cases.

This corresponds to the bug: #572 