### PR TITLE
No lookup error in DS for unexisting sharing

### DIFF
--- a/client/app/lib/request.coffee
+++ b/client/app/lib/request.coffee
@@ -53,3 +53,8 @@ exports.put = (url, data, callback) ->
 exports.del = (url, callback) ->
     exports.request "DELETE", url, null, callback
 
+
+# Sends an exist request
+exports.exist = (id, callback) ->
+    exports.get "data/exist/#{id}/", callback
+

--- a/server/controllers/routes.coffee
+++ b/server/controllers/routes.coffee
@@ -4,6 +4,8 @@ index  = require './index'
 ical   = require './ical'
 contacts = require './contacts'
 sharings = require './sharings'
+utils = require '../helpers/utils'
+
 
 module.exports =
 
@@ -89,3 +91,9 @@ module.exports =
 
     'sharing/refuse':
         post: sharings.refuse
+
+
+    # Data management
+    'data/exist/:id/':
+        get: utils.exist
+

--- a/server/helpers/client.coffee
+++ b/server/helpers/client.coffee
@@ -1,0 +1,17 @@
+# A simple client to be able to send request directly to the data-system.
+
+request = require 'request-json'
+
+
+# The data-system port is configurable.
+DS_PORT = process.env.DS_PORT or 9101
+client  = request.createClient "http://localhost:#{DS_PORT}"
+
+if process.env.NODE_ENV in ["production", "test"]
+    client.setBasicAuth process.env.NAME, process.env.TOKEN
+else
+    client.setBasicAuth Math.random().toString(36), "token"
+
+
+module.exports = client
+

--- a/server/helpers/utils.coffee
+++ b/server/helpers/utils.coffee
@@ -1,0 +1,17 @@
+client = require './client'
+log    = require('printit')
+    prefix: "utils"
+    date  : true
+
+
+module.exports.exist = (req, res) ->
+    id = req.params.id
+
+    client.get "data/exist/#{id}/", (error, response, body) ->
+        if error
+            res.status(500).send error
+        else if not body? or not body.exist?
+            res.status(500).send new Error "Data system returned invalid data."
+        else
+            res.status(200).send body.exist
+


### PR DESCRIPTION
Before this commit when we wanted to get the sharing document associated
with a shared event we attempted a fetch of the document which id
matches the "shareID". The problem was that if we are the recipient of
the shared event no document with this id exists hence resulting in the
data-system returning an error and the client browser displaying a 404
in the console.

To avoid this behavior a new route was created on the server side of the
application to call the route "data/exist/:id" of the data-system.

Having that we now start by asking if a document with that id exists and
if that is the case we fetch it and if not we fetch the appropriate
sharing document. We no longer produce errors.