### PR TITLE
Remove depreciation warning for moment library

### DIFF
--- a/client/app/application.coffee
+++ b/client/app/application.coffee
@@ -88,8 +88,8 @@ module.exports =
             loadedMonths: {}
         now = moment().startOf 'month'
         for i in [1..3]
-            m1 = now.clone().subtract('months', i).format 'YYYY-MM'
-            m2 = now.clone().add('months', i).format 'YYYY-MM'
+            m1 = now.clone().subtract(i, 'months').format 'YYYY-MM'
+            m2 = now.clone().add(i, 'months').format 'YYYY-MM'
             @mainStore.loadedMonths[m1] = true
             @mainStore.loadedMonths[m2] = true
         @mainStore.loadedMonths[now.format 'YYYY-MM'] = true

--- a/client/app/views/calendar_view.coffee
+++ b/client/app/views/calendar_view.coffee
@@ -102,7 +102,7 @@ module.exports = class CalendarView extends BaseView
         # that events are loaded.
         @calHeader.on 'prev', =>
             @clearViewComponents =>
-                monthToLoad = @cal.fullCalendar('getDate').subtract('months', 1)
+                monthToLoad = @cal.fullCalendar('getDate').subtract(1, 'months')
                 window.app.events.loadMonth monthToLoad, =>
                     @cal.fullCalendar 'prev'
 
@@ -110,7 +110,7 @@ module.exports = class CalendarView extends BaseView
         # events are loaded.
         @calHeader.on 'next', =>
             @clearViewComponents =>
-                monthToLoad = @cal.fullCalendar('getDate').add('months', 1)
+                monthToLoad = @cal.fullCalendar('getDate').add(1, 'months')
                 window.app.events.loadMonth monthToLoad, =>
                     @cal.fullCalendar 'next'
 
@@ -121,7 +121,7 @@ module.exports = class CalendarView extends BaseView
             @clearViewComponents =>
                 @cal.fullCalendar 'changeView', 'month'
         @calHeader.on 'list', =>
-            @clearViewComponents =>
+            @clearViewComponents ->
                 window.app.events.sort()
                 app.router.navigate 'list', trigger:true
         @$('#alarms').prepend @calHeader.render().$el
@@ -190,8 +190,9 @@ module.exports = class CalendarView extends BaseView
         options.parentView = @
 
         showNewPopover = =>
-            # @TODO Event creation is a typical core feature of the calendar app,
-            # this part should be moved directly into the app module, and managed
+            # @TODO Event creation is a typical core feature of the calendar
+            # app, this part should be moved directly into the app module, and
+            # managed
             # with event handlers
             model = options.model ?= new Event
                 start: helpers.momentToString options.start
@@ -212,7 +213,7 @@ module.exports = class CalendarView extends BaseView
         if @popover
             # click on same case
             @preventUnselecting()
-            @popover.close =>
+            @popover.close ->
                 showNewPopover()
 
         else
@@ -238,7 +239,7 @@ module.exports = class CalendarView extends BaseView
             callback() if callback and typeof callback is 'function'
 
 
-    getUrlHash: =>
+    getUrlHash: ->
         return 'calendar'
 
 

--- a/server/controllers/events.coffee
+++ b/server/controllers/events.coffee
@@ -254,7 +254,7 @@ module.exports.bulkDelete = (req, res) ->
 module.exports.monthEvents = (req, res, next) ->
     {month, year} = req.params
     start = moment "#{year}-#{month}-01", 'YYYY-MM-DD'
-    end = start.clone().add 'months', 1
+    end = start.clone().add 1, 'months'
 
     Event.load start, end, (err, events) ->
         return next err if err

--- a/server/controllers/index.coffee
+++ b/server/controllers/index.coffee
@@ -51,7 +51,8 @@ module.exports.index = (req, res, next) ->
 
 
         [
-            contacts, tags, calendars, events, pendingEventSharings, instance, webDavAccount, timezone
+            contacts, tags, calendars, events, pendingEventSharings, instance,
+            webDavAccount, timezone
         ] = results
 
         locale = instance?.locale or 'en'

--- a/test/event_model_test.coffee
+++ b/test/event_model_test.coffee
@@ -43,7 +43,7 @@ describe "Events model", ->
 
         it "returns events for dates: 21030401 - 20130501", (done) ->
             start = moment('201304', 'YYYYMM')
-            end = start.clone().add 'months', 1
+            end = start.clone().add 1, 'months'
             Event.load start, end, (err, events) ->
                 events.length.should.equal 2
                 events[0].description.should.equal 'Title 1'
@@ -52,7 +52,7 @@ describe "Events model", ->
 
         it "returns events for dates: 21030401 - 20160401", (done) ->
             start = moment('201304', 'YYYYMM')
-            end = start.clone().add 'years', 3
+            end = start.clone().add 3, 'years'
             Event.load start, end, (err, events) ->
                 events.length.should.equal 3
                 events[0].description.should.equal 'Title 1'
@@ -61,8 +61,8 @@ describe "Events model", ->
                 done()
 
         it "returns no events for dates: 21010401 - 20120401", (done) ->
-            start = moment('201304', 'YYYYMM').subtract 'years', 2
-            end = start.clone().add 'years', 1
+            start = moment('201304', 'YYYYMM').subtract 2, 'years'
+            end = start.clone().add 1, 'years'
             Event.load start, end, (err, events) ->
                 events.length.should.equal 0
                 done()


### PR DESCRIPTION
Two methods were generating warnings and I got tired of it so here are
the modifications… ;-)

There are also fat arrows that are replaced by simple ones, as syntastic
was complaining.