### PR TITLE
Fix bug about dummy event when exporting calendar

### DIFF
--- a/server/controllers/ical.coffee
+++ b/server/controllers/ical.coffee
@@ -30,10 +30,9 @@ createCalendar = (calendarName, callback) ->
         if events.length > 0
             for event in events
                 # first time app opening calendar and new calendar dummy event
-                endDateArray = moment(event.end, 'YYYYMMDD')._a
-                if endDateArray[0] <= 1901
-                    continue
-                calendar.add event.toIcal()
+                isDummyEvent = moment(event.end, 'YYYYMMDD').year() <= 1901
+                if not isDummyEvent
+                    calendar.add event.toIcal()
             callback null, calendar
 
 module.exports.import = (req, res, next) ->

--- a/server/controllers/ical.coffee
+++ b/server/controllers/ical.coffee
@@ -3,6 +3,7 @@ Event = require '../models/event'
 Tag = require '../models/tag'
 User  = require '../models/user'
 multiparty = require 'multiparty'
+moment = require 'moment-timezone'
 fs = require 'fs'
 archiver = require 'archiver'
 async = require 'async'
@@ -27,7 +28,12 @@ createCalendar = (calendarName, callback) ->
         return callback err if err
 
         if events.length > 0
-            calendar.add event.toIcal() for event in events
+            for event in events
+                # first time app opening calendar and new calendar dummy event
+                endDateArray = moment(event.end, 'YYYYMMDD')._a
+                if endDateArray[0] <= 1901
+                    continue
+                calendar.add event.toIcal()
             callback null, calendar
 
 module.exports.import = (req, res, next) ->


### PR DESCRIPTION
Fix #317.
When the calendar app is installed for the first time a dummy event with the exact date 1901-01-01 is created. When a new calendar is created, each time, a dummy event with the date 1901-01-01 RELATED TO THE LOCAL TIMEZONE is created (so 1901-01-01 more or less 12h).
There is no way to tell the difference between the dummy event and another event from the DB, so this fix doesn't export any events for end dates before the year 1901 included.

I choose to detect only the year instead of be more accurate (we could prevent only events of 1901-01-01 and 1900-12-31) to not slow down the performance when exporting a lot of events, while using momentJS to keep date formats compatibility.