### PR TITLE
Handle account.token legacy for webDav accounts

### DIFF
--- a/client/app/views/settings_modal.coffee
+++ b/client/app/views/settings_modal.coffee
@@ -26,6 +26,10 @@ module.exports = class SettingsModals extends BaseView
     initialize: ->
         @model = window.webDavAccount
         if @model?
+            # See https://github.com/cozy/cozy-calendar/issues/549
+            legacyToken = @model.password
+            @model.token = @model.token or legacyToken
+
             @model.placeholder = @getPlaceholder @model.token
 
 


### PR DESCRIPTION
Fix #549

I did not test with a real webDav account but I mocked one in the IndexController and I have been able to reproduce the issue, and then to test my fix.